### PR TITLE
Implement query references

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,8 @@ func Read(path string) (File, error) {
 
 // File is a collection of jobs
 type File struct {
-	Jobs []*Job `yaml:"jobs"`
+	Jobs    []*Job            `yaml:"jobs"`
+	Queries map[string]string `yaml:"queries"`
 }
 
 // Job is a collection of connections and queries
@@ -63,12 +64,13 @@ type connection struct {
 // Query is an SQL query that is executed on a connection
 type Query struct {
 	sync.Mutex
-	log     log.Logger
-	desc    *prometheus.Desc
-	metrics map[*connection][]prometheus.Metric
-	Name    string   `yaml:"name"`   // the prometheus metric name
-	Help    string   `yaml:"help"`   // the prometheus metric help text
-	Labels  []string `yaml:"labels"` // expose these columns as labels per gauge
-	Values  []string `yaml:"values"` // expose each of these as an gauge
-	Query   string   `yaml:"query"`
+	log      log.Logger
+	desc     *prometheus.Desc
+	metrics  map[*connection][]prometheus.Metric
+	Name     string   `yaml:"name"`      // the prometheus metric name
+	Help     string   `yaml:"help"`      // the prometheus metric help text
+	Labels   []string `yaml:"labels"`    // expose these columns as labels per gauge
+	Values   []string `yaml:"values"`    // expose each of these as an gauge
+	Query    string   `yaml:"query"`     // a literal query
+	QueryRef string   `yaml:"query_ref"` // references an query in the query map
 }

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -106,3 +106,13 @@ jobs:
             , idx_blks_read::float
             , idx_blks_hit::float
             FROM pg_statio_user_tables;
+queries:
+  pg_statio_user_tables:    |
+                            SELECT
+                              schemaname::text
+                            , relname::text
+                            , heap_blks_read::float
+                            , heap_blks_hit::float
+                            , idx_blks_read::float
+                            , idx_blks_hit::float
+                            FROM pg_statio_user_tables;

--- a/exporter.go
+++ b/exporter.go
@@ -34,7 +34,7 @@ func NewExporter(logger log.Logger, configFile string) (*Exporter, error) {
 		if job == nil {
 			continue
 		}
-		if err := job.Init(logger); err != nil {
+		if err := job.Init(logger, cfg.Queries); err != nil {
 			level.Warn(logger).Log("msg", "Skipping job. Failed to initialize", "err", err, "job", job.Name)
 			continue
 		}


### PR DESCRIPTION
This commit adds a global map of queries which can be reused
in each job to save duplication of possibly huge queries.

Fixes #7