### PR TITLE
Add Oracle (oci8 driver) support

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     cgo: false
 repository:
-    path: github.com/justwatchcom/sql_exporter
+    path: github.com/mkosiorek/sql_exporter
 build:
     flags: -a -tags netgo
     ldflags: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - .travis/oracle
+  - cd .travis/oracle
   - download.sh
   - install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm | cut -d' ' -f1`
   - sudo ls -R /usr/include/oracle/12.1
   - sudo ls -R $ORACLE_HOME
+  - export PATH="${PATH}:${ORACLE_HOME}/lib"
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";
       echo "Cflags: -I/usr/include/oracle/12.1/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/122010/oracle-instantclient11.2-basic-12.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
-  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
+  - export ORACLE_FILE=instantclient/122010/oracle-instantclient11.2-devel-12.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
-  - sudo ls -R /usr/include/oracle/11.2
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-devel-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
+  - sudo ls -R /usr/include/oracle/12.2
   - sudo ls -R $ORACLE_HOME
   - >
-    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
-      echo "Cflags: -I/usr/include/oracle/11.2/client64/";
+    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.2";
+      echo "Cflags: -I/usr/include/oracle/12.2/client64/";
       echo "Libs: -L$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 
 env:
   global:
-    - ORACLE_HOME=/usr/lib/oracle/11.2/client64
+    - ORACLE_HOME=/usr/lib/oracle/12.2/client64
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
@@ -17,12 +17,12 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - export ORACLE_FILE=instantclient/122010/oracle-instantclient11.2-basic-12.2.0.1.0-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/122010/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
-  - export ORACLE_FILE=instantclient/122010/oracle-instantclient11.2-devel-12.2.0.1.0-1.x86_64.rpm
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
+  - export ORACLE_FILE=instantclient/122010/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-devel-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
   - sudo ls -R /usr/include/oracle/12.2
   - sudo ls -R $ORACLE_HOME
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
-    - ORACLE_DOWNLOAD_DIR=.cache/oracle
 
 before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
@@ -23,6 +22,7 @@ before_install:
   - .travis/oracle/install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
+  - find -name *.rpm
   - .travis/oracle/install.sh
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
-  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
   - sudo ls -R /usr/include/oracle/11.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - sudo ls -R /usr/include/oracle/12.1
   - sudo ls -R $ORACLE_HOME
   - export PATH="${PATH}:${ORACLE_HOME}/lib"
+  - export LD_LIBRARY_PATH="${ORACLE_HOME}/lib"
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";
       echo "Cflags: -I/usr/include/oracle/12.1/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - .travis/oracle/download.sh
   - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
-  - ls -R oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64
+  - ls -R .
   - ls -R /u01/app/oracle/product/11.2.0/xe/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,17 @@ env:
     - PKG_CONFIG_PATH="."
 
 before_install:
-  - go get -d github.com/mattn/go-oci8
-  - $HOME/gopath/src/github.com/mattn/go-oci8/.travis/oracle/download.sh
-  - $HOME/gopath/src/github.com/mattn/go-oci8/.travis/oracle/install.sh
+  - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
+  - mkdir -p .travis/oracle
+  - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
+  - travis/oracle/download.sh
+  - travis/oracle/install.sh
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.1";
       echo "Cflags: -I$ORACLE_HOME/rdbms/public";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
-  - go install github.com/mattn/go-oci8
+  - go get github.com/mattn/go-oci8
 
 script:
   - make style

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";
       echo "Cflags: -I/usr/include/oracle/12.1/client64/";
-      echo "Libs: -L$ORACLE_HOME/lib -lclntsh";
+      echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
+  - sudo /etc/init.d/oracle-xe configure
   - >
-    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.1";
+    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I$ORACLE_HOME/rdbms/public";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - sudo /etc/init.d/oracle-xe configure
+  - ls -R /u01/app/oracle
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I$ORACLE_HOME/rdbms/public";

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - export=ORACLE_HOME=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
+  - export ORACLE_HOME=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - .travis/oracle/download.sh
   - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - ls -R oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,12 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - ORACLE_FILE='instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip'
+  - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
-  - ls -R /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/
-  - ls -R $ORACLE_HOME/lib
+  - .travis/oracle/install.sh
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
-      echo "Cflags: -I/home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/";
+      echo "Cflags: -I/usr/include/oracle/11.2/client64/";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ sudo: required
 env:
   global:
     - ORACLE_HOME=/usr/lib/oracle/11.2/client64
-    - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
 
@@ -18,12 +17,12 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - export ORACLE_FILE=instantclient/10204/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
-  - export ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
+  - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
   - sudo ls -R /usr/include/oracle/11.2
   - sudo ls -R $ORACLE_HOME
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.8
   - tip
 
-install:
+before_script:
   - go get github.com/mattn/go-oci8
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_install:
   - .travis/oracle/download.sh
   - ls -R .cache/oracle
   - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
-  - sudo mkdir -p /usr/include/oracle/11.2
-  - ln -s /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/ /usr/include/oracle/11.2/client64/
+  - sudo mkdir -p /usr/include/oracle/11.2/client64/
+  - sudo cp /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/* /usr/include/oracle/11.2/client64/
   - ls -R /usr/include/oracle
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ sudo: required
 
 env:
   global:
-    - ORACLE_FILE=oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+    - ORACLE_COOKIE=sqldev
+    - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
     - PKG_CONFIG_PATH="."

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
       echo "Cflags: -I/usr/include/oracle/12.1/client64/";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
-  - go get github.com/mattn/go-oci8
 
 script:
   - make style

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - .travis/oracle/download.sh
-  - .travis/oracle/install.sh
+  - .travis/oracle
+  - download.sh
+  - install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
-  - .travis/oracle/download.sh
-  - find -name *.rpm
-  - .travis/oracle/install.sh
+  - download.sh
+  - install.sh
+  - cd
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - PKG_CONFIG_PATH="."
 
 before_install:
+  - sudo apt-get --no-install-recommends -qq install alien bc libaio1 unzip
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
   - 1.8
   - tip
 
+install:
+  - go get github.com/mattn/go-oci8
+
 script:
   - make style
   - make vet

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - travis/oracle/download.sh
-  - travis/oracle/install.sh
+  - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.1";
       echo "Cflags: -I$ORACLE_HOME/rdbms/public";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: required
 
 env:
   global:
-    - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
@@ -19,8 +18,9 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
+  - ORACLE_FILE=instantclient/10204/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - .travis/oracle/install.sh
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 
 env:
   global:
-    - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+    - ORACLE_HOME=/usr/lib/oracle/11.2/client64
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - export ORACLE_HOME=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
+  - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - .travis/oracle/download.sh
   - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - ls -R oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,11 @@ before_install:
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
+  - ls -R /usr/include/oracle/11.2
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";
-      echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
+      echo "Libs: -L$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
+    - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
 
 before_install:
@@ -20,7 +21,11 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - ls -R /u01/app/oracle
+  - export=ORACLE_HOME=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
+  - .travis/oracle/download.sh
+  - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
+  - ls -R oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64
+  - ls -R /u01/app/oracle/product/11.2.0/xe/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I$ORACLE_HOME/rdbms/public";

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,11 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm'
+  - ORACLE_FILE='instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip'
   - .travis/oracle/download.sh
   - ls -R .cache/oracle
-  - .travis/oracle/install.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm'
-  - .travis/oracle/download.sh
-  - .travis/oracle/install.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm'
-  - .travis/oracle/download.sh
-  - .travis/oracle/install.sh
+  - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
+  - ls -R .
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ before_install:
   - .travis/oracle/download.sh
   - ls -R .cache/oracle
   - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
-  - ls -R .
+  - sudo mkdir -p /usr/include/oracle/11.2
+  - ln -s /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/ /usr/include/oracle/11.2/client64/
+  - ls -R /usr/include/oracle
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ sudo: required
 env:
   global:
     - ORACLE_HOME=/usr/lib/oracle/11.2/client64
+    - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
-
 before_install:
   - sudo apt-get --no-install-recommends -qq install alien bc libaio1 unzip
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
@@ -22,7 +22,7 @@ before_install:
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
   - export ORACLE_FILE=instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm | cut -d' ' -f1`
   - sudo ls -R /usr/include/oracle/11.2
   - sudo ls -R $ORACLE_HOME
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ before_install:
   - .travis/oracle/install.sh
   - ORACLE_FILE='instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip'
   - .travis/oracle/download.sh
-  - ls -R .cache/oracle
   - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
+  - ls -R /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/
+  - ls -R $ORACLE_HOME/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ before_install:
   - export ORACLE_FILE=instantclient/121020/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm | cut -d' ' -f1`
-  - sudo ls -R /usr/include/oracle/12.1
-  - sudo ls -R $ORACLE_HOME
-  - export PATH="${PATH}:${ORACLE_HOME}/lib"
   - export LD_LIBRARY_PATH="${ORACLE_HOME}/lib"
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
+    - ORACLE_DOWNLOAD_DIR=.cache/oracle
 
 before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
@@ -20,11 +21,16 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm' download.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm' download.sh
-  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm' download.sh
-  - sudo apt-get -qq install libaio1 rpm
-  - sudo rpm --install --nodeps oracle-instantclient11.2-*.rpm
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm'
+  - .travis/oracle/download.sh
+  - ls -R .cache/oracle
+  - .travis/oracle/install.sh
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm'
+  - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm'
+  - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,11 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - cd .travis/oracle
-  - ./download.sh
-  - ./install.sh
+  - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
-  - ./download.sh
-  - ./install.sh
-  - cd
+  - .travis/oracle/download.sh
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ before_install:
   - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-devel-11.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - ls -R .
-  - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
-  - ls -R /u01/app/oracle/product/11.2.0/xe/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,25 @@ go:
   - 1.8
   - tip
 
-before_script:
-  - go get github.com/mattn/go-oci8
+sudo: required
+
+env:
+  global:
+    - ORACLE_FILE=oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+    - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+    - ORACLE_SID=XE
+    - PKG_CONFIG_PATH="."
+
+before_install:
+  - go get -d github.com/mattn/go-oci8
+  - $HOME/gopath/src/github.com/mattn/go-oci8/.travis/oracle/download.sh
+  - $HOME/gopath/src/github.com/mattn/go-oci8/.travis/oracle/install.sh
+  - >
+    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.1";
+      echo "Cflags: -I$ORACLE_HOME/rdbms/public";
+      echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
+    } | tee oci8.pc
+  - go install github.com/mattn/go-oci8
 
 script:
   - make style

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_install:
   - export ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
-  - ls -R /usr/include/oracle/11.2
+  - sudo ls -R /usr/include/oracle/11.2
+  - sudo ls -R $ORACLE_HOME
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ before_install:
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - cd .travis/oracle
-  - download.sh
-  - install.sh
+  - ./download.sh
+  - ./install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
-  - download.sh
-  - install.sh
+  - ./download.sh
+  - ./install.sh
   - cd
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - .travis/oracle/install.sh
   - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - .travis/oracle/download.sh
-  - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - ls -R .
+  - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - ls -R /u01/app/oracle/product/11.2.0/xe/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - export ORACLE_FILE=instantclient/121020/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm | cut -d' ' -f1`
+  - export PATH="${PATH}:${ORACLE_HOME}/lib"
   - export LD_LIBRARY_PATH="${ORACLE_HOME}/lib"
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,9 @@ before_install:
   - .travis/oracle/download.sh
   - ls -R .cache/oracle
   - unzip .cache/oracle/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip -d client64
-  - sudo mkdir -p /usr/include/oracle/11.2/client64/
-  - sudo cp /home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/* /usr/include/oracle/11.2/client64/
-  - ls -R /usr/include/oracle
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
-      echo "Cflags: -I/usr/include/oracle/11.2/client64/";
+      echo "Cflags: -I/home/travis/gopath/src/github.com/mkosiorek/sql_exporter/client64/instantclient_11_2/sdk/include/";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - ORACLE_FILE=instantclient/10204/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/10204/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-basic-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
-  - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
   - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
   - ls -R /usr/include/oracle/11.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ sudo: required
 
 env:
   global:
-    - ORACLE_COOKIE=sqldev
     - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
-    - ORACLE_COOKIE=ic_linuxx8664
+    - ORACLE_COOKIE=sqldev
     - PKG_CONFIG_PATH="."
 
 before_install:
@@ -21,14 +20,15 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
+  - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-devel-11.2.0.1.0-1.x86_64.rpm
   - .travis/oracle/download.sh
+  - .travis/oracle/install.sh
   - ls -R .
   - unzip oracle-instantclient11.2-sdk-11.2.0.1.0-1.x86_64.zip
   - ls -R /u01/app/oracle/product/11.2.0/xe/lib
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
-      echo "Cflags: -I$ORACLE_HOME/rdbms/public";
+      echo "Cflags: -I/usr/include/oracle/11.2/client64/";
       echo "Libs: -L$ORACLE_HOME/lib -Wl,-rpath,$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - .travis/oracle/install.sh
   - ORACLE_FILE=instantclient/10204/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient-devel-10.2.0.4-1.x86_64.rpm | cut -d' ' -f1`
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
-    - ORACLE_COOKIE=sqldev
+    - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
 
 before_install:
@@ -20,9 +20,11 @@ before_install:
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
   - .travis/oracle/download.sh
   - .travis/oracle/install.sh
-  - export ORACLE_FILE=instantclient/112010/oracle-instantclient11.2-devel-11.2.0.1.0-1.x86_64.rpm
-  - .travis/oracle/download.sh
-  - .travis/oracle/install.sh
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm' download.sh
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-devel-11.2.0.4.0-1.x86_64.rpm' download.sh
+  - ORACLE_FILE='instantclient/11204/oracle-instantclient11.2-sqlplus-11.2.0.4.0-1.x86_64.rpm' download.sh
+  - sudo apt-get -qq install libaio1 rpm
+  - sudo rpm --install --nodeps oracle-instantclient11.2-*.rpm
   - >
     { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 11.2";
       echo "Cflags: -I/usr/include/oracle/11.2/client64/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 
 env:
   global:
-    - ORACLE_HOME=/usr/lib/oracle/12.2/client64
+    - ORACLE_HOME=/usr/lib/oracle/12.1/client64
     - ORACLE_SID=XE
     - ORACLE_COOKIE=ic_linuxx8664
     - PKG_CONFIG_PATH="."
@@ -17,17 +17,17 @@ before_install:
   - wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
   - mkdir -p .travis/oracle
   - tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-  - export ORACLE_FILE=instantclient/122010/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm
+  - export ORACLE_FILE=instantclient/121020/oracle-instantclient12.1-basic-12.1.0.2.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
-  - export ORACLE_FILE=instantclient/122010/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.1-basic-12.1.0.2.0-1.x86_64.rpm | cut -d' ' -f1`
+  - export ORACLE_FILE=instantclient/121020/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm
   - .travis/oracle/download.sh
-  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm | cut -d' ' -f1`
-  - sudo ls -R /usr/include/oracle/12.2
+  - sudo dpkg --install `sudo alien --scripts --to-deb .travis/oracle/oracle-instantclient12.1-devel-12.1.0.2.0-1.x86_64.rpm | cut -d' ' -f1`
+  - sudo ls -R /usr/include/oracle/12.1
   - sudo ls -R $ORACLE_HOME
   - >
-    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.2";
-      echo "Cflags: -I/usr/include/oracle/12.2/client64/";
+    { echo "Name: oci8"; echo "Description: Oracle Call Interface"; echo "Version: 12.1";
+      echo "Cflags: -I/usr/include/oracle/12.1/client64/";
       echo "Libs: -L$ORACLE_HOME/lib -lclntsh";
     } | tee oci8.pc
   - go get github.com/mattn/go-oci8

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains an service that runs user-defined SQL queries at flexib
 Status
 ======
 
-Actively used with PostgreSQL in production. We'd like to eventually support all databases for which stable Go database [drivers](https://github.com/golang/go/wiki/SQLDrivers) are available. Contributions welcome.
+Actively used with [PostgreSQL](http:/github.com/lib/pq) and [Oracle](https://github.com/mattn/go-oci8) in production. We'd like to eventually support all databases for which stable Go database [drivers](https://github.com/golang/go/wiki/SQLDrivers) are available. Contributions welcome.
 
 What does it look like?
 =======================
@@ -105,6 +105,8 @@ jobs:
   # each query will be executed on each connection
   connections:
   - 'postgres://postgres@localhost/postgres?sslmode=disable'
+  # for Oracle: 
+  # - 'oci8://user/password@host:port/sid'
   # queries is a map of Metric/Query mappings
   queries:
     # name is prefied with sql_ and used as the metric name

--- a/job.go
+++ b/job.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/kshvakov/clickhouse" // register the ClickHouse driver
 	_ "github.com/lib/pq"              // register the PostgreSQL driver
+	_ "github.com/mattn/go-oci8"       // register the Oracle driver
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -59,7 +60,7 @@ func (j *Job) Init(logger log.Logger, queries map[string]string) error {
 		q.desc = prometheus.NewDesc(
 			name,
 			help,
-			append(q.Labels, "driver", "host", "database", "user", "col"),
+			append(q.Labels, "col"),
 			prometheus.Labels{
 				"sql_job": j.Name,
 			},
@@ -182,6 +183,8 @@ func (c *connection) connect(iv time.Duration) error {
 	switch c.url.Scheme {
 	case "mysql":
 		dsn = strings.TrimPrefix(dsn, "mysql://")
+	case "oci8":
+		dsn = strings.TrimPrefix(dsn, "oci8://")
 	case "clickhouse":
 		dsn = "tcp://" + strings.TrimPrefix(dsn, "clickhouse://")
 	}

--- a/query.go
+++ b/query.go
@@ -36,12 +36,12 @@ func (q *Query) Run(conn *connection) error {
 		res := make(map[string]interface{})
 		err := rows.MapScan(res)
 		if err != nil {
-			level.Error(q.log).Log("msg", "Failed to scan", "err", err, "host", conn.host, "db", conn.database)
+			level.Error(q.log).Log("msg", "Failed to scan", "err", err)
 			continue
 		}
 		m, err := q.updateMetrics(conn, res)
 		if err != nil {
-			level.Error(q.log).Log("msg", "Failed to update metrics", "err", err, "host", conn.host, "db", conn.database)
+			level.Error(q.log).Log("msg", "Failed to update metrics", "err", err)
 			continue
 		}
 		metrics = append(metrics, m...)
@@ -71,8 +71,6 @@ func (q *Query) updateMetrics(conn *connection, res map[string]interface{}) ([]p
 				"msg", "Failed to update metric",
 				"value", valueName,
 				"err", err,
-				"host", conn.host,
-				"db", conn.database,
 			)
 			continue
 		}
@@ -124,7 +122,7 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 	}
 	// make space for all defined variable label columns and the "static" labels
 	// added below
-	labels := make([]string, 0, len(q.Labels)+5)
+	labels := make([]string, 0, len(q.Labels)+1)
 	for _, label := range q.Labels {
 		// we need to fill every spot in the slice or the key->value mapping
 		// won't match up in the end.
@@ -143,10 +141,6 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 		}
 		labels = append(labels, lv)
 	}
-	labels = append(labels, conn.driver)
-	labels = append(labels, conn.host)
-	labels = append(labels, conn.database)
-	labels = append(labels, conn.user)
 	labels = append(labels, valueName)
 	// create a new immutable const metric that can be cached and returned on
 	// every scrape. Remember that the order of the lable values in the labels

--- a/vendor/github.com/mattn/go-oci8/README.md
+++ b/vendor/github.com/mattn/go-oci8/README.md
@@ -1,0 +1,84 @@
+go-oci8
+=======
+
+[![Build Status](https://travis-ci.org/mattn/go-oci8.svg)](https://travis-ci.org/mattn/go-oci8)
+
+Description
+-----------
+
+Oracle driver conforming to the built-in database/sql interface
+
+Installation
+------------
+
+This package can be installed with the go get command:
+
+    go get github.com/mattn/go-oci8
+
+You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below.
+
+### Example for Windows
+
+```
+prefix=/devel/target/XXXXXXXXXXXXXXXXXXXXXXXXXX
+exec_prefix=${prefix}
+libdir=c:/oraclexe/app/oracle/product/11.2.0/server/oci/lib/msvc
+includedir=c:/oraclexe/app/oracle/product/11.2.0/server/oci/include/include
+
+glib_genmarshal=glib-genmarshal
+gobject_query=gobject-query
+glib_mkenums=glib-mkenums
+
+Name: oci8
+Description: oci8 library
+Libs: -L${libdir} -loci
+Cflags: -I${includedir}
+Version: 11.2
+```
+
+### Example for Linux
+
+```
+prefix=/devel/target/XXXXXXXXXXXXXXXXXXXXXXXXXX
+exec_prefix=${prefix}
+libdir=/usr/lib/oracle/11.2/client64/lib
+includedir=/usr/include/oracle/11.2/client64
+
+glib_genmarshal=glib-genmarshal
+gobject_query=gobject-query
+glib_mkenums=glib-mkenums
+
+Name: oci8
+Description: oci8 library
+Libs: -L${libdir} -lclntsh
+Cflags: -I${includedir}
+Version: 11.2
+```
+
+Documentation
+-------------
+
+API documentation can be found here: http://godoc.org/github.com/mattn/go-oci8
+
+Examples can be found under the `./_example` directory
+
+License
+-------
+
+MIT: http://mattn.mit-license.org/2014
+
+ToDo
+----
+
+* LastInserted is not int64
+* Fetch number is more improvable
+
+Author
+------
+
+Yasuhiro Matsumoto (a.k.a mattn)
+
+Special Thanks
+--------------
+
+Jamil Djadala

--- a/vendor/github.com/mattn/go-oci8/dsn.go
+++ b/vendor/github.com/mattn/go-oci8/dsn.go
@@ -1,0 +1,357 @@
+package oci8
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+// partial copy of go1.5 net/url, modified to parse oracle dsn,
+// support '/' & ':' as user:password separators
+
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+type encoding int
+
+const (
+	encodePath encoding = 1 + iota
+	encodeHost
+	encodeUserPassword
+	encodeQueryComponent
+)
+
+type EscapeError string
+
+func (e EscapeError) Error() string {
+	return "invalid URL escape " + strconv.Quote(string(e))
+}
+
+// Return true if the specified character should be escaped when
+// appearing in a URL string, according to RFC 3986.
+//
+// Please be informed that for now shouldEscape does not check all
+// reserved characters correctly. See golang.org/issue/5684.
+func shouldEscape(c byte, mode encoding) bool {
+	// §2.3 Unreserved characters (alphanum)
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+
+	if mode == encodeHost {
+		// §3.2.2 Host allows
+		//	sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+		// as part of reg-name.
+		// We add : because we include :port as part of host.
+		// We add [ ] because we include [ipv6]:port as part of host
+		switch c {
+		case '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', ':', '[', ']':
+			return false
+		}
+	}
+
+	switch c {
+	case '-', '_', '.', '~': // §2.3 Unreserved characters (mark)
+		return false
+
+	case '$', '&', '+', ',', '/', ':', ';', '=', '?', '@': // §2.2 Reserved characters (reserved)
+		// Different sections of the URL allow a few of
+		// the reserved characters to appear unescaped.
+		switch mode {
+		case encodePath: // §3.3
+			// The RFC allows : @ & = + $ but saves / ; , for assigning
+			// meaning to individual path segments. This package
+			// only manipulates the path as a whole, so we allow those
+			// last two as well. That leaves only ? to escape.
+			return c == '?'
+
+		case encodeUserPassword: // §3.2.1
+			// The RFC allows ';', ':', '&', '=', '+', '$', and ',' in
+			// userinfo, so we must escape only '@', '/', and '?'.
+			// The parsing of userinfo treats ':' as special so we must escape
+			// that too.
+			return c == '@' || c == '/' || c == '?' || c == ':'
+
+		case encodeQueryComponent: // §3.4
+			// The RFC reserves (so we must escape) everything.
+			return true
+
+		}
+	}
+
+	// Everything else must be escaped.
+	return true
+}
+
+// QueryUnescape does the inverse transformation of QueryEscape, converting
+// %AB into the byte 0xAB and '+' into ' ' (space). It returns an error if
+// any % is not followed by two hexadecimal digits.
+func QueryUnescape(s string) (string, error) {
+	return unescape(s, encodeQueryComponent)
+}
+
+// unescape unescapes a string; the mode specifies
+// which section of the URL string is being unescaped.
+func unescape(s string, mode encoding) (string, error) {
+	// Count %, check that they're well-formed.
+	n := 0
+	hasPlus := false
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			n++
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				s = s[i:]
+				if len(s) > 3 {
+					s = s[:3]
+				}
+				return "", EscapeError(s)
+			}
+			i += 3
+		case '+':
+			hasPlus = mode == encodeQueryComponent
+			i++
+		default:
+			i++
+		}
+	}
+
+	if n == 0 && !hasPlus {
+		return s, nil
+	}
+
+	t := make([]byte, len(s)-2*n)
+	j := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '%':
+			t[j] = unhex(s[i+1])<<4 | unhex(s[i+2])
+			j++
+			i += 3
+		case '+':
+			if mode == encodeQueryComponent {
+				t[j] = ' '
+			} else {
+				t[j] = '+'
+			}
+			j++
+			i++
+		default:
+			t[j] = s[i]
+			j++
+			i++
+		}
+	}
+	return string(t), nil
+}
+
+// QueryEscape escapes the string so it can be safely placed
+// inside a URL query.
+func QueryEscape(s string) string {
+	return escape(s, encodeQueryComponent)
+}
+
+func escape(s string, mode encoding) string {
+	spaceCount, hexCount := 0, 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c, mode) {
+			if c == ' ' && mode == encodeQueryComponent {
+				spaceCount++
+			} else {
+				hexCount++
+			}
+		}
+	}
+
+	if spaceCount == 0 && hexCount == 0 {
+		return s
+	}
+
+	t := make([]byte, len(s)+2*hexCount)
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == ' ' && mode == encodeQueryComponent:
+			t[j] = '+'
+			j++
+		case shouldEscape(c, mode):
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}
+
+// Maybe s is of the form t c u.
+// If so, return  t, u.
+// If not, return s, "".
+func split(s string, c string) (string, string) {
+	i := strings.Index(s, c)
+	if i < 0 {
+		return s, ""
+	}
+	return s[:i], s[i+len(c):]
+}
+
+func splitRight(s string, c string) (string, string) {
+	i := strings.LastIndex(s, c)
+	if i < 0 {
+		return s, ""
+	}
+	return s[:i], s[i+len(c):]
+}
+
+func parseAuthority(authority string) (user, pass string, err error) {
+
+	if i := strings.IndexAny(authority, ":/"); i < 0 {
+		if authority, err = unescape(authority, encodeUserPassword); err != nil {
+			return "", "", err
+		}
+		user = authority
+	} else {
+		username, password := split(authority, authority[i:i+1])
+		if username, err = unescape(username, encodeUserPassword); err != nil {
+			return "", "", err
+		}
+		if password, err = unescape(password, encodeUserPassword); err != nil {
+			return "", "", err
+		}
+		user, pass = username, password
+	}
+	return user, pass, nil
+}
+
+// Values maps a string key to a list of values.
+// It is typically used for query parameters and form values.
+// Unlike in the http.Header map, the keys in a Values map
+// are case-sensitive.
+type Values map[string][]string
+
+// Get gets the first value associated with the given key.
+// If there are no values associated with the key, Get returns
+// the empty string. To access multiple values, use the map
+// directly.
+func (v Values) Get(key string) string {
+	if v == nil {
+		return ""
+	}
+	vs, ok := v[key]
+	if !ok || len(vs) == 0 {
+		return ""
+	}
+	return vs[0]
+}
+
+// Set sets the key to value. It replaces any existing
+// values.
+func (v Values) Set(key, value string) {
+	v[key] = []string{value}
+}
+
+// Add adds the value to key. It appends to any existing
+// values associated with key.
+func (v Values) Add(key, value string) {
+	v[key] = append(v[key], value)
+}
+
+// Del deletes the values associated with key.
+func (v Values) Del(key string) {
+	delete(v, key)
+}
+
+// ParseQuery parses the URL-encoded query string and returns
+// a map listing the values specified for each key.
+// ParseQuery always returns a non-nil map containing all the
+// valid query parameters found; err describes the first decoding error
+// encountered, if any.
+func ParseQuery(query string) (m Values, err error) {
+	m = make(Values)
+	err = parseQuery(m, query)
+	return
+}
+
+func parseQuery(m Values, query string) (err error) {
+	for query != "" {
+		key := query
+		if i := strings.IndexAny(key, "&;"); i >= 0 {
+			key, query = key[:i], key[i+1:]
+		} else {
+			query = ""
+		}
+		if key == "" {
+			continue
+		}
+		value := ""
+		if i := strings.Index(key, "="); i >= 0 {
+			key, value = key[:i], key[i+1:]
+		}
+		key, err1 := QueryUnescape(key)
+		if err1 != nil {
+			if err == nil {
+				err = err1
+			}
+			continue
+		}
+		value, err1 = QueryUnescape(value)
+		if err1 != nil {
+			if err == nil {
+				err = err1
+			}
+			continue
+		}
+		m[key] = append(m[key], value)
+	}
+	return err
+}
+
+// Encode encodes the values into ``URL encoded'' form
+// ("bar=baz&foo=quux") not sorted by key
+func (v Values) Encode() string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	for _, k := range keys {
+		vs := v[k]
+		prefix := QueryEscape(k) + "="
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			buf.WriteString(QueryEscape(v))
+		}
+	}
+	return buf.String()
+}

--- a/vendor/github.com/mattn/go-oci8/oci8.go
+++ b/vendor/github.com/mattn/go-oci8/oci8.go
@@ -1,0 +1,2129 @@
+package oci8
+
+/*
+#include <oci.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#cgo pkg-config: oci8
+
+typedef struct {
+  char err[1024];
+  sword rv;
+} retErr;
+
+static retErr
+WrapOCIErrorGet(OCIError *err) {
+  retErr vvv;
+  sb4 errcode;
+  OCIErrorGet(err, 1, NULL, &errcode, (OraText*) vvv.err, sizeof(vvv.err), OCI_HTYPE_ERROR);
+  return vvv;
+}
+
+typedef struct {
+  int num;
+  sword rv;
+} retInt;
+
+static retInt
+WrapOCIAttrGetInt(dvoid *ss, ub4 hType, ub4 aType, OCIError *err) {
+  retInt vvv = {0, 0};
+  vvv.rv = OCIAttrGet(
+    ss,
+    hType,
+    &vvv.num,
+    NULL,
+    aType,
+    err);
+  return vvv;
+}
+
+typedef struct {
+  ub2 num;
+  sword rv;
+} retUb2;
+
+static retUb2
+WrapOCIAttrGetUb2(dvoid *ss, ub4 hType, ub4 aType, OCIError *err) {
+  retUb2 vvv = {0, 0};
+  vvv.rv = OCIAttrGet(
+    ss,
+    hType,
+    &vvv.num,
+    NULL,
+    aType,
+    err);
+  return vvv;
+}
+
+typedef struct {
+  ub4 num;
+  sword rv;
+} retUb4;
+
+static retUb4
+WrapOCIAttrGetUb4(dvoid *ss, ub4 hType, ub4 aType, OCIError *err) {
+  retUb4 vvv = {0,0};
+  vvv.rv = OCIAttrGet(
+    ss,
+    hType,
+    &vvv.num,
+    NULL,
+    aType,
+    err);
+  return vvv;
+}
+
+typedef struct {
+  OraText rowid[19];
+  sword rv;
+} retRowid;
+
+static retRowid
+WrapOCIAttrRowId(dvoid *ss, dvoid *st, ub4 hType, ub4 aType, OCIError *err) {
+  OCIRowid *ptr;
+  ub4 size;
+  retRowid vvv;
+  vvv.rv = OCIDescriptorAlloc(
+    ss,
+    (dvoid*)&ptr,
+    OCI_DTYPE_ROWID,
+    0,
+    NULL);
+  if (vvv.rv == OCI_SUCCESS) {
+    vvv.rv = OCIAttrGet(
+      st,
+      hType,
+      ptr,
+      &size,
+      aType,
+      err);
+    if (vvv.rv == OCI_SUCCESS) {
+      ub2 idsize = 18;
+      memset(vvv.rowid, 0, sizeof(vvv.rowid));
+      vvv.rv = OCIRowidToChar(ptr, vvv.rowid, &idsize, err);
+    }
+  }
+  return vvv;
+}
+
+typedef struct {
+  char *ptr;
+  ub4 size;
+  sword rv;
+} retString;
+
+static retString
+WrapOCIAttrGetString(dvoid *ss, ub4 hType, ub4 aType, OCIError *err) {
+  retString vvv = {NULL, 0, 0};
+  vvv.rv = OCIAttrGet(
+    ss,
+    hType,
+    &vvv.ptr,
+    &vvv.size,
+    aType,
+    err);
+  return vvv;
+}
+
+typedef struct {
+  dvoid *ptr;
+  sword rv;
+} ret1ptr;
+
+typedef struct {
+  dvoid *ptr;
+  dvoid *extra;
+  sword rv;
+} ret2ptr;
+
+static ret1ptr
+WrapOCIParamGet(dvoid *ss, ub4 hType, OCIError *err, ub4 pos) {
+  ret1ptr vvv = {NULL, 0};
+  vvv.rv = OCIParamGet(
+    ss,
+    hType,
+    err,
+    &vvv.ptr,
+    pos);
+  return vvv;
+}
+
+static ret2ptr
+WrapOCIDescriptorAlloc(dvoid *env, ub4 type, size_t extra) {
+  ret2ptr vvv = {NULL, NULL, 0};
+  void *ptr;
+  if (extra == 0) {
+    ptr = NULL;
+  } else {
+    ptr = &vvv.extra;
+  }
+  vvv.rv = OCIDescriptorAlloc(
+    env,
+    &vvv.ptr,
+    type,
+    extra,
+    ptr);
+  return vvv;
+}
+
+static ret2ptr
+WrapOCIHandleAlloc(dvoid *parrent, ub4 type, size_t extra) {
+  ret2ptr vvv = {NULL, NULL, 0};
+  void *ptr;
+  if (extra == 0) {
+    ptr = NULL;
+  } else {
+    ptr = &vvv.extra;
+  }
+  vvv.rv = OCIHandleAlloc(
+    parrent,
+    &vvv.ptr,
+    type,
+    extra,
+    ptr);
+  return vvv;
+}
+
+static ret2ptr
+WrapOCIEnvCreate(ub4 mode, size_t extra) {
+  OCIEnv *env;
+  ub2 charsetid = 0;
+  ret2ptr vvv = {NULL, NULL, 0};
+  void *ptr;
+  if (extra == 0)  {
+    ptr = NULL;
+  } else {
+    ptr = &vvv.extra;
+  }
+  if (getenv("NLS_LANG") == NULL && !OCIEnvInit(&env, OCI_DEFAULT, 0, NULL)) {
+    charsetid = OCINlsCharSetNameToId(env, (const oratext*)"AL32UTF8");
+    OCIHandleFree(env, OCI_HTYPE_ENV);
+  }
+
+  vvv.rv = OCIEnvNlsCreate(
+    (OCIEnv**)(&vvv.ptr),
+    mode,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    extra,
+    ptr,
+    charsetid,
+    charsetid);
+  return vvv;
+}
+
+static ret1ptr
+WrapOCILogon(OCIEnv *env, OCIError *err, OraText *u, ub4 ulen, OraText *p, ub4 plen, OraText *h, ub4 hlen) {
+  ret1ptr vvv = {NULL, 0};
+  vvv.rv = OCILogon(
+    env,
+    err,
+    (OCISvcCtx**)(&vvv.ptr),
+    u,
+    ulen,
+    p,
+    plen,
+    h,
+    hlen);
+  return vvv;
+}
+
+static ret1ptr
+WrapOCIServerAttach(OCIServer *srv, OCIError *err, text *dblink, ub4 dblinklen, ub4 mode) {
+  ret1ptr vvv = {NULL, 0};
+  vvv.rv = OCIServerAttach(
+    srv,
+    err,
+    dblink,
+    dblinklen,
+    mode);
+  return vvv;
+}
+
+static ret1ptr
+WrapOCISessionBegin(OCISvcCtx *srv, OCIError *err, OCISession *usr, ub4 credt, ub4 mode) {
+  ret1ptr vvv = {NULL, 0};
+  vvv.rv = OCISessionBegin(
+    srv,
+    err,
+    usr,
+    credt,
+    mode);
+  return vvv;
+}
+
+typedef struct {
+  ub4 ff;
+  sb2 y;
+  ub1 m, d, hh, mm, ss;
+  sword rv;
+} retTime;
+
+static retTime
+WrapOCIDateTimeGetDateTime(OCIEnv *env, OCIError *err, OCIDateTime *tptr) {
+  retTime vvv;
+
+  vvv.rv = OCIDateTimeGetDate(
+    env,
+    err,
+    tptr,
+    &vvv.y,
+    &vvv.m,
+    &vvv.d);
+  if (vvv.rv != OCI_SUCCESS) {
+    return vvv;
+  }
+  vvv.rv = OCIDateTimeGetTime(
+    env,
+    err,
+    tptr,
+    &vvv.hh,
+    &vvv.mm,
+    &vvv.ss,
+    &vvv.ff);
+  return vvv;
+}
+
+typedef struct {
+  sb1 h, m;
+  ub1 zone[90]; // = max timezone name len
+  ub4 zlen;
+  sword rv;
+} retZone;
+
+static retZone
+WrapOCIDateTimeGetTimeZoneNameOffset(OCIEnv *env, OCIError *err, OCIDateTime *tptr) {
+  retZone vvv;
+  vvv.zlen = sizeof(vvv.zone);
+
+  vvv.rv = OCIDateTimeGetTimeZoneName(
+    env,
+    err,
+    tptr,
+    vvv.zone,
+    &vvv.zlen);
+  if (vvv.rv != OCI_SUCCESS) {
+    return vvv;
+  }
+  vvv.rv = OCIDateTimeGetTimeZoneOffset(
+    env,
+    err,
+    tptr,
+    &vvv.h,
+    &vvv.m);
+  return vvv;
+}
+
+typedef struct {
+  sb4 d, hh, mm, ss, ff;
+  sword rv;
+} retIntervalDS;
+
+static retIntervalDS
+WrapOCIIntervalGetDaySecond(OCIEnv *env, OCIError *err, OCIInterval *ptr) {
+  retIntervalDS vvv;
+  vvv.rv = OCIIntervalGetDaySecond(
+    env,
+    err,
+    &vvv.d,
+    &vvv.hh,
+    &vvv.mm,
+    &vvv.ss,
+    &vvv.ff,
+    ptr);
+  return vvv;
+}
+
+typedef struct {
+  sb4 y, m;
+  sword rv;
+} retIntervalYM;
+
+static retIntervalYM
+WrapOCIIntervalGetYearMonth(OCIEnv *env, OCIError *err, OCIInterval *ptr) {
+  retIntervalYM vvv;
+  vvv.rv = OCIIntervalGetYearMonth(
+    env,
+    err,
+    &vvv.y,
+    &vvv.m,
+    ptr);
+  return vvv;
+}
+
+static sword
+WrapOCIAttrSetUb4(dvoid *h, ub4 type, ub4 value, ub4  attrtype, OCIError *err) {
+  return OCIAttrSet(h, type, &value, 0, attrtype, err);
+}
+
+typedef struct  {
+	sb2 ind;
+	ub2 rlen;
+} indrlen;
+
+*/
+import "C"
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/net/context"
+)
+
+const blobBufSize = 4000
+const useOCISessionBegin = true
+
+/**
+ORA-03114: Not Connected to Oracle
+ORA-01012: Not logged on
+ORA-03113: end-of-file on communication channel
+ORA-12528: TNS:listener: all appropriate instances are blocking new connections
+ORA-12537: TNS:connection closed
+ORA-01033: ORACLE initialization or shutdown in progress
+ORA-01034: ORACLE not available
+*/
+var badConnCodes = []string{"ORA-03114", "ORA-01012", "ORA-03113", "ORA-12528", "ORA-12537", "ORA-01033", "ORA-01034"}
+
+type DSN struct {
+	Connect              string
+	Username             string
+	Password             string
+	prefetch_rows        uint32
+	prefetch_memory      uint32
+	Location             *time.Location
+	transactionMode      C.ub4
+	enableQMPlaceholders bool
+	operationMode        C.ub4
+}
+
+func init() {
+	sql.Register("oci8", &OCI8Driver{})
+}
+
+type OCI8Driver struct {
+}
+
+type OCI8Conn struct {
+	svc                  unsafe.Pointer
+	srv                  unsafe.Pointer
+	env                  unsafe.Pointer
+	err                  unsafe.Pointer
+	usr_session          unsafe.Pointer
+	prefetch_rows        uint32
+	prefetch_memory      uint32
+	location             *time.Location
+	transactionMode      C.ub4
+	operationMode        C.ub4
+	inTransaction        bool
+	enableQMPlaceholders bool
+	closed               bool
+}
+
+type OCI8Tx struct {
+	c *OCI8Conn
+}
+
+// ParseDSN parses a DSN used to connect to Oracle
+// It expects to receive a string in the form:
+// user:password@host:port/sid?param1=value1&param2=value2
+//
+// Currently the parameters supported is:
+// 1 'loc' which
+// sets the timezone to read times in as and to marshal to when writing times to
+// Oracle date,
+// 2 'isolation' =READONLY,SERIALIZABLE,DEFAULT
+// 3 'prefetch_rows'
+// 4 'prefetch_memory'
+// 5 'questionph' =YES,NO,TRUE,FALSE enable question-mark placeholders, default to false
+func ParseDSN(dsnString string) (dsn *DSN, err error) {
+
+	dsn = &DSN{Location: time.Local}
+
+	if dsnString == "" {
+		return nil, errors.New("empty dsn")
+	}
+
+	const prefix = "oracle://"
+
+	if strings.HasPrefix(dsnString, prefix) {
+		dsnString = dsnString[len(prefix):]
+	}
+
+	authority, dsnString := splitRight(dsnString, "@")
+	if authority != "" {
+		dsn.Username, dsn.Password, err = parseAuthority(authority)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	host, params := splitRight(dsnString, "?")
+
+	if host, err = unescape(host, encodeHost); err != nil {
+		return nil, err
+	}
+
+	dsn.Connect = host
+
+	// set safe defaults
+	dsn.prefetch_rows = 10
+	dsn.prefetch_memory = 0
+	dsn.operationMode = C.OCI_DEFAULT
+
+	qp, err := ParseQuery(params)
+	for k, v := range qp {
+		switch k {
+		case "loc":
+			if len(v) > 0 {
+				if dsn.Location, err = time.LoadLocation(v[0]); err != nil {
+					return nil, fmt.Errorf("Invalid loc: %v: %v", v[0], err)
+				}
+			}
+		case "isolation":
+			switch v[0] {
+			case "READONLY":
+				dsn.transactionMode = C.OCI_TRANS_READONLY
+			case "SERIALIZABLE":
+				dsn.transactionMode = C.OCI_TRANS_SERIALIZABLE
+			case "DEFAULT":
+				dsn.transactionMode = C.OCI_TRANS_READWRITE
+			default:
+				return nil, fmt.Errorf("Invalid isolation: %v", v[0])
+			}
+		case "questionph":
+			switch v[0] {
+			case "YES", "TRUE":
+				dsn.enableQMPlaceholders = true
+			case "NO", "FALSE":
+				dsn.enableQMPlaceholders = false
+			default:
+				return nil, fmt.Errorf("Invalid questionpm: %v", v[0])
+			}
+		case "prefetch_rows":
+			z, err := strconv.ParseUint(v[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prefetch_rows: %v", v[0])
+			}
+			dsn.prefetch_rows = uint32(z)
+		case "prefetch_memory":
+			z, err := strconv.ParseUint(v[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prefetch_memory: %v", v[0])
+			}
+			dsn.prefetch_memory = uint32(z)
+			//default:
+			//log.Println("unused parameter", k)
+		case "as":
+			switch v[0] {
+			case "SYSDBA", "sysdba":
+				dsn.operationMode = C.OCI_SYSDBA
+			case "SYSOPER", "sysoper":
+				dsn.operationMode = C.OCI_SYSOPER
+			default:
+				return nil, fmt.Errorf("Invalid as: %v", v[0])
+			}
+
+		}
+	}
+	return dsn, nil
+}
+
+func (tx *OCI8Tx) Commit() error {
+	tx.c.inTransaction = false
+	if rv := C.OCITransCommit(
+		(*C.OCISvcCtx)(tx.c.svc),
+		(*C.OCIError)(tx.c.err),
+		0); rv != C.OCI_SUCCESS {
+		return ociGetError(rv, tx.c.err)
+	}
+	return nil
+}
+
+func (tx *OCI8Tx) Rollback() error {
+	tx.c.inTransaction = false
+	if rv := C.OCITransRollback(
+		(*C.OCISvcCtx)(tx.c.svc),
+		(*C.OCIError)(tx.c.err),
+		0); rv != C.OCI_SUCCESS {
+		return ociGetError(rv, tx.c.err)
+	}
+	return nil
+}
+
+type namedValue struct {
+	Name    string
+	Ordinal int
+	Value   driver.Value
+}
+
+type outValue struct {
+	Dest interface{}
+	In   bool
+}
+
+func (c *OCI8Conn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	list := make([]namedValue, len(args))
+	for i, v := range args {
+		list[i] = namedValue{
+			Ordinal: i + 1,
+			Value:   v,
+		}
+	}
+	return c.exec(context.Background(), query, list)
+}
+
+func (c *OCI8Conn) exec(ctx context.Context, query string, args []namedValue) (driver.Result, error) {
+	s, err := c.prepare(ctx, query)
+	defer s.Close()
+	if err != nil {
+		return nil, err
+	}
+	res, err := s.(*OCI8Stmt).exec(ctx, args)
+	if err != nil && err != driver.ErrSkip {
+		return nil, err
+	}
+	return res, nil
+}
+
+/*
+FIXME:
+Queryer is disabled because of incresing cursor numbers.
+See https://github.com/mattn/go-oci8/issues/151
+OCIStmtExecute doesn't return anything to close resource.
+This mean that OCI8Rows.Close can't close statement handle. For example,
+prepared statement is called twice like below.
+
+    stmt, _ := db.Prepare("...")
+    stmt.QueryRow().Scan(&x)
+    stmt.QueryRow().Scan(&x)
+
+If OCI8Rows close handle of statement, this fails.
+
+// Query implements Queryer.
+func (c *OCI8Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	list := make([]namedValue, len(args))
+	for i, v := range args {
+		list[i] = namedValue{
+			Ordinal: i + 1,
+			Value:   v,
+		}
+	}
+	rows, err := c.query(context.Background(), query, list)
+	if err != nil {
+		return nil, err
+	}
+	rows.(*OCI8Rows).cls = true
+	return rows, err
+}
+*/
+
+func (c *OCI8Conn) query(ctx context.Context, query string, args []namedValue) (driver.Rows, error) {
+	s, err := c.prepare(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.(*OCI8Stmt).query(ctx, args)
+	if err != nil && err != driver.ErrSkip {
+		s.Close()
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (c *OCI8Conn) ping(ctx context.Context) error {
+	rv := C.OCIPing(
+		(*C.OCISvcCtx)(c.svc),
+		(*C.OCIError)(c.err),
+		C.OCI_DEFAULT)
+	if rv != C.OCI_SUCCESS {
+		return errors.New("ping failed")
+	}
+	return nil
+}
+
+func (c *OCI8Conn) Begin() (driver.Tx, error) {
+	return c.begin(context.Background())
+}
+
+func (c *OCI8Conn) begin(ctx context.Context) (driver.Tx, error) {
+	if c.transactionMode != C.OCI_TRANS_READWRITE {
+		var th unsafe.Pointer
+		if rv := C.WrapOCIHandleAlloc(
+			c.env,
+			C.OCI_HTYPE_TRANS,
+			0); rv.rv != C.OCI_SUCCESS {
+			return nil, errors.New("can't allocate handle")
+		} else {
+			th = rv.ptr
+		}
+		if rv := C.OCIAttrSet(
+			c.svc,
+			C.OCI_HTYPE_SVCCTX,
+			th,
+			0,
+			C.OCI_ATTR_TRANS,
+			(*C.OCIError)(c.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, c.err)
+		}
+
+		if rv := C.OCITransStart(
+			(*C.OCISvcCtx)(c.svc),
+			(*C.OCIError)(c.err),
+			0,
+			c.transactionMode); // C.OCI_TRANS_SERIALIZABLE C.OCI_TRANS_READWRITE C.OCI_TRANS_READONLY
+		rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, c.err)
+		}
+	}
+	c.inTransaction = true
+	return &OCI8Tx{c}, nil
+}
+
+func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) {
+	var (
+		conn OCI8Conn
+		dsn  *DSN
+	)
+
+	if dsn, err = ParseDSN(dsnString); err != nil {
+		return nil, err
+	}
+
+	conn.operationMode = dsn.operationMode
+
+	if rv := C.WrapOCIEnvCreate(
+		C.OCI_DEFAULT|C.OCI_THREADED,
+		0); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
+		// TODO: error handle not yet allocated, we can't get string error from oracle
+		return nil, errors.New("can't OCIEnvCreate")
+	} else {
+		conn.env = rv.ptr
+	}
+
+	if rv := C.WrapOCIHandleAlloc(
+		conn.env,
+		C.OCI_HTYPE_ERROR,
+		0); rv.rv != C.OCI_SUCCESS {
+		return nil, errors.New("cant allocate error handle")
+	} else {
+		conn.err = rv.ptr
+	}
+
+	phost := C.CString(dsn.Connect)
+	defer C.free(unsafe.Pointer(phost))
+	puser := C.CString(dsn.Username)
+	defer C.free(unsafe.Pointer(puser))
+	ppass := C.CString(dsn.Password)
+	defer C.free(unsafe.Pointer(ppass))
+
+	if useOCISessionBegin {
+		if rv := C.WrapOCIHandleAlloc(
+			conn.env,
+			C.OCI_HTYPE_SERVER,
+			0); rv.rv != C.OCI_SUCCESS {
+			return nil, errors.New("cant allocate server handle")
+		} else {
+			conn.srv = rv.ptr
+		}
+
+		C.WrapOCIServerAttach(
+			(*C.OCIServer)(conn.srv),
+			(*C.OCIError)(conn.err),
+			(*C.text)(unsafe.Pointer(phost)),
+			C.ub4(len(dsn.Connect)),
+			C.OCI_DEFAULT)
+
+		if rv := C.WrapOCIHandleAlloc(
+			conn.env,
+			C.OCI_HTYPE_SVCCTX,
+			0); rv.rv != C.OCI_SUCCESS {
+			return nil, errors.New("cant allocate service handle")
+		} else {
+			conn.svc = rv.ptr
+		}
+
+		if rv := C.OCIAttrSet(
+			conn.svc,
+			C.OCI_HTYPE_SVCCTX,
+			conn.srv,
+			0,
+			C.OCI_ATTR_SERVER,
+			(*C.OCIError)(conn.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, conn.err)
+		}
+
+		// allocate a user session handle
+		if rv := C.WrapOCIHandleAlloc(
+			conn.env,
+			C.OCI_HTYPE_SESSION,
+			0); rv.rv != C.OCI_SUCCESS {
+			return nil, errors.New("cant allocate user session handle")
+		} else {
+			conn.usr_session = rv.ptr
+		}
+
+		//  set username attribute in user session handle
+		if rv := C.OCIAttrSet(
+			conn.usr_session,
+			C.OCI_HTYPE_SESSION,
+			(unsafe.Pointer(puser)),
+			C.ub4(len(dsn.Username)),
+			C.OCI_ATTR_USERNAME,
+			(*C.OCIError)(conn.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, conn.err)
+		}
+
+		// set password attribute in the user session handle
+		if rv := C.OCIAttrSet(
+			conn.usr_session,
+			C.OCI_HTYPE_SESSION,
+			(unsafe.Pointer(ppass)),
+			C.ub4(len(dsn.Password)),
+			C.OCI_ATTR_PASSWORD,
+			(*C.OCIError)(conn.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, conn.err)
+		}
+
+		// begin the session
+		C.WrapOCISessionBegin(
+			(*C.OCISvcCtx)(conn.svc),
+			(*C.OCIError)(conn.err),
+			(*C.OCISession)(conn.usr_session),
+			C.OCI_CRED_RDBMS,
+			conn.operationMode)
+
+		// set the user session attribute in the service context handle
+		if rv := C.OCIAttrSet(
+			conn.svc,
+			C.OCI_HTYPE_SVCCTX,
+			conn.usr_session,
+			0,
+			C.OCI_ATTR_SESSION,
+			(*C.OCIError)(conn.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, conn.err)
+		}
+
+	} else {
+		if rv := C.WrapOCILogon(
+			(*C.OCIEnv)(conn.env),
+			(*C.OCIError)(conn.err),
+			(*C.OraText)(unsafe.Pointer(puser)),
+			C.ub4(len(dsn.Username)),
+			(*C.OraText)(unsafe.Pointer(ppass)),
+			C.ub4(len(dsn.Password)),
+			(*C.OraText)(unsafe.Pointer(phost)),
+			C.ub4(len(dsn.Connect))); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
+			// fmt.Print(rv.rv)
+			return nil, ociGetError(rv.rv, conn.err)
+		} else {
+			conn.svc = rv.ptr
+		}
+
+	}
+
+	conn.location = dsn.Location
+	conn.transactionMode = dsn.transactionMode
+	conn.prefetch_rows = dsn.prefetch_rows
+	conn.prefetch_memory = dsn.prefetch_memory
+	conn.enableQMPlaceholders = dsn.enableQMPlaceholders
+	return &conn, nil
+}
+
+func (c *OCI8Conn) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	var err error
+	if useOCISessionBegin {
+		// OCISessionEnd() and OCIServerDetach()
+		if rv := C.OCISessionEnd(
+			(*C.OCISvcCtx)(c.svc),
+			(*C.OCIError)(c.err),
+			(*C.OCISession)(c.usr_session),
+			C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
+			err = ociGetError(rv, c.err)
+		}
+		if rv := C.OCIServerDetach(
+			(*C.OCIServer)(c.srv),
+			(*C.OCIError)(c.err),
+			C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
+			err = ociGetError(rv, c.err)
+		}
+	} else {
+
+		if rv := C.OCILogoff(
+			(*C.OCISvcCtx)(c.svc),
+			(*C.OCIError)(c.err)); rv != C.OCI_SUCCESS {
+			err = ociGetError(rv, c.err)
+		}
+	}
+
+	C.OCIHandleFree(
+		c.env,
+		C.OCI_HTYPE_ENV)
+
+	c.svc = nil
+	c.env = nil
+	c.err = nil
+	return err
+}
+
+type OCI8Stmt struct {
+	c      *OCI8Conn
+	s      unsafe.Pointer
+	closed bool
+	bp     **C.OCIBind
+	defp   **C.OCIDefine
+	pbind  []oci8bind //bind params
+}
+
+func (c *OCI8Conn) Prepare(query string) (driver.Stmt, error) {
+	return c.prepare(context.Background(), query)
+}
+
+func (c *OCI8Conn) prepare(ctx context.Context, query string) (driver.Stmt, error) {
+	if c.enableQMPlaceholders {
+		query = placeholders(query)
+	}
+	pquery := C.CString(query)
+	defer C.free(unsafe.Pointer(pquery))
+	var s, bp, defp unsafe.Pointer
+
+	if rv := C.WrapOCIHandleAlloc(
+		c.env,
+		C.OCI_HTYPE_STMT,
+		(C.size_t)(unsafe.Sizeof(bp)*2)); rv.rv != C.OCI_SUCCESS {
+		return nil, ociGetError(rv.rv, c.err)
+	} else {
+		s = rv.ptr
+		bp = rv.extra
+		defp = unsafe.Pointer(uintptr(rv.extra) + unsafe.Sizeof(unsafe.Pointer(nil)))
+	}
+
+	if rv := C.OCIStmtPrepare(
+		(*C.OCIStmt)(s),
+		(*C.OCIError)(c.err),
+		(*C.OraText)(unsafe.Pointer(pquery)),
+		C.ub4(C.strlen(pquery)),
+		C.ub4(C.OCI_NTV_SYNTAX),
+		C.ub4(C.OCI_DEFAULT)); rv != C.OCI_SUCCESS {
+		return nil, ociGetError(rv, c.err)
+	}
+
+	ss := &OCI8Stmt{c: c, s: s, bp: (**C.OCIBind)(bp), defp: (**C.OCIDefine)(defp)}
+	runtime.SetFinalizer(ss, (*OCI8Stmt).Close)
+	return ss, nil
+}
+
+func (s *OCI8Stmt) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
+	runtime.SetFinalizer(s, nil)
+	C.OCIHandleFree(
+		s.s,
+		C.OCI_HTYPE_STMT)
+	s.s = nil
+	s.pbind = nil
+	return nil
+}
+
+func (s *OCI8Stmt) NumInput() int {
+	r := C.WrapOCIAttrGetInt(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_BIND_COUNT, (*C.OCIError)(s.c.err))
+	if r.rv != C.OCI_SUCCESS {
+		return -1
+	}
+	return int(r.num)
+}
+
+func freeBoundParameters(boundParameters []oci8bind) {
+	for _, col := range boundParameters {
+		if col.pbuf != nil {
+			switch col.kind {
+			case C.SQLT_CLOB, C.SQLT_BLOB:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_LOB)
+			case C.SQLT_TIMESTAMP:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_TIMESTAMP)
+			case C.SQLT_TIMESTAMP_TZ:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_TIMESTAMP_TZ)
+			case C.SQLT_TIMESTAMP_LTZ:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_TIMESTAMP_LTZ)
+			case C.SQLT_INTERVAL_DS:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_INTERVAL_DS)
+			case C.SQLT_INTERVAL_YM:
+				freeDecriptor(col.pbuf, C.OCI_DTYPE_INTERVAL_YM)
+			default:
+				C.free(col.pbuf)
+			}
+			col.pbuf = nil
+		}
+	}
+}
+
+func getInt64(p unsafe.Pointer) int64 {
+	return int64(*(*C.sb8)(p))
+}
+
+func outputBoundParameters(boundParameters []oci8bind) {
+	for _, col := range boundParameters {
+		if col.pbuf != nil {
+			switch v := col.out.(type) {
+			case *string:
+				*v = C.GoString((*C.char)(col.pbuf))
+			case *int:
+				*v = int(getInt64(col.pbuf))
+			case *int64:
+				*v = getInt64(col.pbuf)
+			case *int32:
+				*v = int32(getInt64(col.pbuf))
+			case *int16:
+				*v = int16(getInt64(col.pbuf))
+			case *int8:
+				*v = int8(getInt64(col.pbuf))
+
+			case *float64:
+
+				buf := (*[1 << 30]byte)(col.pbuf)[0:8]
+				f := uint64(buf[7])
+				f |= uint64(buf[6]) << 8
+				f |= uint64(buf[5]) << 16
+				f |= uint64(buf[4]) << 24
+				f |= uint64(buf[3]) << 32
+				f |= uint64(buf[2]) << 40
+				f |= uint64(buf[1]) << 48
+				f |= uint64(buf[0]) << 56
+
+				// Don't know why bits are inverted that way, but it works
+				if buf[0]&0x80 == 0 {
+					f ^= 0xffffffffffffffff
+				} else {
+					f &= 0x7fffffffffffffff
+				}
+
+				*v = math.Float64frombits(f)
+
+			case *bool:
+				buf := (*[1 << 30]byte)(col.pbuf)[0:1]
+				*v = buf[0] != 0
+			}
+		}
+	}
+}
+
+func (s *OCI8Stmt) bind(args []namedValue) ([]oci8bind, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	var (
+		boundParameters []oci8bind
+		err             error
+	)
+	*s.bp = nil
+	for i, uv := range args {
+		var sbind oci8bind
+
+		vv := uv.Value
+		if out, ok := vv.(outValue); ok {
+			sbind.out = out.Dest
+			vv, err = driver.DefaultParameterConverter.ConvertValue(out.Dest)
+			if err != nil {
+				defer freeBoundParameters(boundParameters)
+				return nil, err
+			}
+		}
+
+		switch v := vv.(type) {
+		case nil:
+			sbind.kind = C.SQLT_STR
+			sbind.pbuf = nil
+			sbind.clen = 0
+		case []byte:
+			sbind.kind = C.SQLT_BIN
+			sbind.pbuf = unsafe.Pointer(CByte(v))
+			sbind.clen = C.sb4(len(v))
+
+		case float64:
+			fb := math.Float64bits(v)
+			if fb&0x8000000000000000 != 0 {
+				fb ^= 0xffffffffffffffff
+			} else {
+				fb |= 0x8000000000000000
+			}
+			sbind.kind = C.SQLT_IBDOUBLE
+			sbind.pbuf = unsafe.Pointer(CByte([]byte{byte(fb >> 56), byte(fb >> 48), byte(fb >> 40), byte(fb >> 32), byte(fb >> 24), byte(fb >> 16), byte(fb >> 8), byte(fb)}))
+			sbind.clen = 8
+
+		case time.Time:
+
+			var pt unsafe.Pointer
+			var zp unsafe.Pointer
+
+			zone, offset := v.Zone()
+
+			size := len(zone)
+			if size < 8 {
+				size = 8
+			}
+			size += int(unsafe.Sizeof(unsafe.Pointer(nil)))
+			if ret := C.WrapOCIDescriptorAlloc(
+				s.c.env,
+				C.OCI_DTYPE_TIMESTAMP_TZ,
+				C.size_t(size)); ret.rv != C.OCI_SUCCESS {
+				defer freeBoundParameters(boundParameters)
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+				sbind.kind = C.SQLT_TIMESTAMP_TZ
+				sbind.clen = C.sb4(unsafe.Sizeof(pt))
+				pt = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+				zp = unsafe.Pointer(uintptr(ret.extra) + unsafe.Sizeof(unsafe.Pointer(nil)))
+			}
+
+			tryagain := false
+
+			copy((*[1 << 30]byte)(zp)[0:len(zone)], zone)
+			rv := C.OCIDateTimeConstruct(
+				s.c.env,
+				(*C.OCIError)(s.c.err),
+				(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)),
+				C.sb2(v.Year()),
+				C.ub1(v.Month()),
+				C.ub1(v.Day()),
+				C.ub1(v.Hour()),
+				C.ub1(v.Minute()),
+				C.ub1(v.Second()),
+				C.ub4(v.Nanosecond()),
+				(*C.OraText)(zp),
+				C.size_t(len(zone)),
+			)
+			if rv != C.OCI_SUCCESS {
+				tryagain = true
+			} else {
+				//check if oracle timezone offset is same ?
+				rvz := C.WrapOCIDateTimeGetTimeZoneNameOffset(
+					(*C.OCIEnv)(s.c.env),
+					(*C.OCIError)(s.c.err),
+					(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)))
+				if rvz.rv != C.OCI_SUCCESS {
+					defer freeBoundParameters(boundParameters)
+					return nil, ociGetError(rvz.rv, s.c.err)
+				}
+				if offset != int(rvz.h)*60*60+int(rvz.m)*60 {
+					//fmt.Println("oracle timezone offset dont match", zone, offset, int(rvz.h)*60*60+int(rvz.m)*60)
+					tryagain = true
+				}
+			}
+
+			if tryagain {
+				sign := '+'
+				if offset < 0 {
+					offset = -offset
+					sign = '-'
+				}
+				offset /= 60
+				// oracle accept zones "[+-]hh:mm", try second time
+				zone = fmt.Sprintf("%c%02d:%02d", sign, offset/60, offset%60)
+
+				copy((*[1 << 30]byte)(zp)[0:len(zone)], zone)
+				rv := C.OCIDateTimeConstruct(
+					s.c.env,
+					(*C.OCIError)(s.c.err),
+					(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)),
+					C.sb2(v.Year()),
+					C.ub1(v.Month()),
+					C.ub1(v.Day()),
+					C.ub1(v.Hour()),
+					C.ub1(v.Minute()),
+					C.ub1(v.Second()),
+					C.ub4(v.Nanosecond()),
+					(*C.OraText)(zp),
+					C.size_t(len(zone)),
+				)
+				if rv != C.OCI_SUCCESS {
+					defer freeBoundParameters(boundParameters)
+					return nil, ociGetError(rv, s.c.err)
+				}
+			}
+
+			sbind.pbuf = unsafe.Pointer((*C.char)(pt))
+
+		case string:
+			sbind.kind = C.SQLT_AFC // don't trim strings !!!
+			sbind.pbuf = unsafe.Pointer(C.CString(v))
+			sbind.clen = C.sb4(len(v))
+
+		case int64:
+			sbind.kind = C.SQLT_INT
+			sbind.clen = C.sb4(8) // not tested on i386. may only work on amd64
+			sbind.pbuf = unsafe.Pointer((*C.char)(C.malloc(8)))
+			buf := (*[1 << 30]byte)(sbind.pbuf)[0:8]
+			buf[0] = byte(v & 0x0ff)
+			buf[1] = byte(v >> 8 & 0x0ff)
+			buf[2] = byte(v >> 16 & 0x0ff)
+			buf[3] = byte(v >> 24 & 0x0ff)
+			buf[4] = byte(v >> 32 & 0x0ff)
+			buf[5] = byte(v >> 40 & 0x0ff)
+			buf[6] = byte(v >> 48 & 0x0ff)
+			buf[7] = byte(v >> 56 & 0x0ff)
+
+		case bool: // oracle dont have bool, handle as 0/1
+			sbind.kind = C.SQLT_INT
+			sbind.clen = C.sb4(1)
+			sbind.pbuf = unsafe.Pointer((*C.char)(C.malloc(8)))
+			if v {
+				(*[1]byte)(sbind.pbuf)[0] = 1
+			} else {
+				(*[1]byte)(sbind.pbuf)[0] = 0
+			}
+
+		default:
+			if sbind.out != nil {
+				sbind.kind = C.SQLT_STR
+			} else {
+				sbind.kind = C.SQLT_CHR
+				d := fmt.Sprintf("%v", v)
+				sbind.clen = C.sb4(len(d))
+				sbind.pbuf = unsafe.Pointer(C.CString(d))
+			}
+		}
+
+		if uv.Name != "" {
+			name := ":" + uv.Name
+			cname := C.CString(name)
+			defer C.free(unsafe.Pointer(cname))
+			if rv := C.OCIBindByName(
+				(*C.OCIStmt)(s.s),
+				s.bp,
+				(*C.OCIError)(s.c.err),
+				(*C.OraText)(unsafe.Pointer(cname)),
+				C.sb4(len(name)),
+				unsafe.Pointer(sbind.pbuf),
+				sbind.clen,
+				sbind.kind,
+				nil,
+				nil,
+				nil,
+				0,
+				nil,
+				C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
+			}
+		} else {
+			if rv := C.OCIBindByPos(
+				(*C.OCIStmt)(s.s),
+				s.bp,
+				(*C.OCIError)(s.c.err),
+				C.ub4(i+1),
+				unsafe.Pointer(sbind.pbuf),
+				sbind.clen,
+				sbind.kind,
+				nil,
+				nil,
+				nil,
+				0,
+				nil,
+				C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
+				defer freeBoundParameters(s.pbind)
+				return nil, ociGetError(rv, s.c.err)
+			}
+		}
+		boundParameters = append(boundParameters, sbind)
+	}
+	return boundParameters, nil
+}
+
+func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
+	list := make([]namedValue, len(args))
+	for i, v := range args {
+		list[i] = namedValue{
+			Ordinal: i + 1,
+			Value:   v,
+		}
+	}
+	return s.query(context.Background(), list)
+}
+
+func (s *OCI8Stmt) query(ctx context.Context, args []namedValue) (driver.Rows, error) {
+	var (
+		fbp []oci8bind
+		err error
+	)
+
+	if fbp, err = s.bind(args); err != nil {
+		return nil, err
+	}
+
+	defer freeBoundParameters(fbp)
+
+	iter := C.ub4(1)
+	if retUb2 := C.WrapOCIAttrGetUb2(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_STMT_TYPE, (*C.OCIError)(s.c.err)); retUb2.rv != C.OCI_SUCCESS {
+		return nil, ociGetError(retUb2.rv, s.c.err)
+	} else if retUb2.num == C.OCI_STMT_SELECT {
+		iter = 0
+	}
+
+	// set the row prefetch.  Only one extra row per fetch will be returned unless this is set.
+	if s.c.prefetch_rows > 0 {
+		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, C.ub4(s.c.prefetch_rows), C.OCI_ATTR_PREFETCH_ROWS, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, s.c.err)
+		}
+	}
+
+	// if non-zero, oci will fetch rows until the memory limit or row prefetch limit is hit.
+	// useful for memory constrained systems
+	if s.c.prefetch_memory > 0 {
+		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, C.ub4(s.c.prefetch_memory), C.OCI_ATTR_PREFETCH_MEMORY, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, s.c.err)
+		}
+	}
+
+	mode := C.ub4(C.OCI_DEFAULT)
+	if !s.c.inTransaction {
+		mode = mode | C.OCI_COMMIT_ON_SUCCESS
+	}
+	if rv := C.OCIStmtExecute(
+		(*C.OCISvcCtx)(s.c.svc),
+		(*C.OCIStmt)(s.s),
+		(*C.OCIError)(s.c.err),
+		iter,
+		0,
+		nil,
+		nil,
+		mode); rv != C.OCI_SUCCESS {
+		return nil, ociGetError(rv, s.c.err)
+	}
+
+	var rc int
+	if retUb2 := C.WrapOCIAttrGetUb2(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_PARAM_COUNT, (*C.OCIError)(s.c.err)); retUb2.rv != C.OCI_SUCCESS {
+		return nil, ociGetError(retUb2.rv, s.c.err)
+	} else {
+		rc = int(retUb2.num)
+	}
+
+	oci8cols := make([]oci8col, rc)
+	indrlenptr := C.calloc(C.size_t(rc), C.sizeof_indrlen)
+	indrlen := (*[1 << 16]C.indrlen)(indrlenptr)[0:rc]
+	for i := 0; i < rc; i++ {
+		var p unsafe.Pointer
+		var tp C.ub2
+		var lp C.ub2
+
+		if rp := C.WrapOCIParamGet(s.s, C.OCI_HTYPE_STMT, (*C.OCIError)(s.c.err), C.ub4(i+1)); rp.rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rp.rv, s.c.err)
+		} else {
+			p = rp.ptr
+		}
+
+		if tpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_TYPE, (*C.OCIError)(s.c.err)); tpr.rv != C.OCI_SUCCESS {
+			return nil, ociGetError(tpr.rv, s.c.err)
+		} else {
+			tp = tpr.num
+		}
+
+		if nsr := C.WrapOCIAttrGetString(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_NAME, (*C.OCIError)(s.c.err)); nsr.rv != C.OCI_SUCCESS {
+			return nil, ociGetError(nsr.rv, s.c.err)
+		} else {
+			oci8cols[i].name = string((*[1 << 30]byte)(unsafe.Pointer(nsr.ptr))[0:int(nsr.size)])
+		}
+
+		if lpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_SIZE, (*C.OCIError)(s.c.err)); lpr.rv != C.OCI_SUCCESS {
+			return nil, ociGetError(lpr.rv, s.c.err)
+		} else {
+			lp = lpr.num
+		}
+		*s.defp = nil
+		switch tp {
+
+		case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_VCS, C.SQLT_AVC:
+			// TODO: transfer as clob, read all bytes in loop
+			// lp *= 4 // utf8 enc
+			oci8cols[i].kind = C.SQLT_CHR  // tp
+			oci8cols[i].size = int(lp) * 4 // utf8 enc
+			oci8cols[i].pbuf = C.malloc(C.size_t(oci8cols[i].size) + 1)
+
+		case C.SQLT_BIN:
+			oci8cols[i].kind = C.SQLT_BIN
+			oci8cols[i].size = int(lp)
+			oci8cols[i].pbuf = C.malloc(C.size_t(oci8cols[i].size))
+
+		case C.SQLT_NUM:
+			oci8cols[i].kind = C.SQLT_CHR
+			oci8cols[i].size = int(lp * 4)
+			oci8cols[i].pbuf = C.malloc(C.size_t(oci8cols[i].size) + 1)
+
+		case C.SQLT_IBDOUBLE, C.SQLT_IBFLOAT:
+			oci8cols[i].kind = C.SQLT_IBDOUBLE
+			oci8cols[i].size = int(8)
+			oci8cols[i].pbuf = C.malloc(8)
+
+		case C.SQLT_LNG:
+			oci8cols[i].kind = C.SQLT_BIN
+			oci8cols[i].size = 2000
+			oci8cols[i].pbuf = C.malloc(C.size_t(oci8cols[i].size))
+
+		case C.SQLT_CLOB, C.SQLT_BLOB:
+			// allocate +io buffers + ub4
+			size := int(unsafe.Sizeof(unsafe.Pointer(nil)) + unsafe.Sizeof(C.ub4(0)))
+			if oci8cols[i].size < blobBufSize {
+				size += blobBufSize
+			} else {
+				size += oci8cols[i].size
+			}
+			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_LOB, C.size_t(size)); ret.rv != C.OCI_SUCCESS {
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+
+				oci8cols[i].kind = tp
+				oci8cols[i].size = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+				oci8cols[i].pbuf = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+
+			}
+
+			//      testing
+			//		case C.SQLT_DAT:
+			//
+			//			oci8cols[i].kind = C.SQLT_DAT
+			//			oci8cols[i].size = int(lp)
+			//			oci8cols[i].pbuf = C.malloc(C.size_t(lp))
+			//
+
+		case C.SQLT_TIMESTAMP, C.SQLT_DAT:
+			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_TIMESTAMP, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+
+				oci8cols[i].kind = C.SQLT_TIMESTAMP
+				oci8cols[i].size = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+				oci8cols[i].pbuf = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+			}
+
+		case C.SQLT_TIMESTAMP_TZ, C.SQLT_TIMESTAMP_LTZ:
+			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_TIMESTAMP_TZ, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+
+				oci8cols[i].kind = C.SQLT_TIMESTAMP_TZ
+				oci8cols[i].size = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+				oci8cols[i].pbuf = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+			}
+
+		case C.SQLT_INTERVAL_DS:
+			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_INTERVAL_DS, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+
+				oci8cols[i].kind = C.SQLT_INTERVAL_DS
+				oci8cols[i].size = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+				oci8cols[i].pbuf = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+			}
+
+		case C.SQLT_INTERVAL_YM:
+			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_INTERVAL_YM, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
+				return nil, ociGetError(ret.rv, s.c.err)
+			} else {
+
+				oci8cols[i].kind = C.SQLT_INTERVAL_YM
+				oci8cols[i].size = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+				oci8cols[i].pbuf = ret.extra
+				*(*unsafe.Pointer)(ret.extra) = ret.ptr
+			}
+
+		case C.SQLT_RDD: // rowid
+			lp = 40
+			oci8cols[i].pbuf = C.malloc(C.size_t(lp) + 1)
+			oci8cols[i].kind = C.SQLT_CHR // tp
+			oci8cols[i].size = int(lp + 1)
+
+		default:
+			oci8cols[i].pbuf = C.malloc(C.size_t(lp) + 1)
+			oci8cols[i].kind = C.SQLT_CHR // tp
+			oci8cols[i].size = int(lp + 1)
+		}
+
+		oci8cols[i].ind = &indrlen[i].ind
+		oci8cols[i].rlen = &indrlen[i].rlen
+
+		if rv := C.OCIDefineByPos(
+			(*C.OCIStmt)(s.s),
+			s.defp,
+			(*C.OCIError)(s.c.err),
+			C.ub4(i+1),
+			oci8cols[i].pbuf,
+			C.sb4(oci8cols[i].size),
+			oci8cols[i].kind,
+			unsafe.Pointer(oci8cols[i].ind),
+			oci8cols[i].rlen,
+			nil,
+			C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
+			C.free(indrlenptr)
+			return nil, ociGetError(rv, s.c.err)
+		}
+	}
+
+	rows := &OCI8Rows{
+		s:          s,
+		cols:       oci8cols,
+		e:          false,
+		indrlenptr: indrlenptr,
+		closed:     false,
+		done:       make(chan struct{}),
+		cls:        false,
+	}
+
+	go func() {
+		select {
+		case <-rows.done:
+		case <-ctx.Done():
+			// select again to avoid race condition if both are done
+			select {
+			case <-rows.done:
+			default:
+				C.OCIBreak(
+					unsafe.Pointer(s.c.svc),
+					(*C.OCIError)(s.c.err))
+				rows.Close()
+			}
+		}
+	}()
+
+	return rows, nil
+}
+
+// OCI_ATTR_ROWID must be get in handle -> alloc
+// can be coverted to char, but not to int64
+
+func (s *OCI8Stmt) lastInsertId() (int64, error) {
+	retRowid := C.WrapOCIAttrRowId(s.c.env, s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_ROWID, (*C.OCIError)(s.c.err))
+	if retRowid.rv == C.OCI_SUCCESS {
+		bs := make([]byte, 18)
+		for i, b := range retRowid.rowid[:18] {
+			bs[i] = byte(b)
+		}
+		rowid := string(bs)
+		return int64(uintptr(unsafe.Pointer(&rowid))), nil
+	}
+	return int64(0), nil
+}
+
+func GetLastInsertId(id int64) string {
+	return *(*string)(unsafe.Pointer(uintptr(id)))
+}
+
+func (s *OCI8Stmt) rowsAffected() (int64, error) {
+	retUb4 := C.WrapOCIAttrGetUb4(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_ROW_COUNT, (*C.OCIError)(s.c.err))
+	if retUb4.rv != C.OCI_SUCCESS {
+		return 0, ociGetError(retUb4.rv, s.c.err)
+	}
+	return int64(retUb4.num), nil
+}
+
+type OCI8Result struct {
+	n     int64
+	errn  error
+	id    int64
+	errid error
+	s     *OCI8Stmt
+}
+
+func (r *OCI8Result) LastInsertId() (int64, error) {
+	return r.id, r.errid
+}
+
+func (r *OCI8Result) RowsAffected() (int64, error) {
+	return r.n, r.errn
+}
+
+func (s *OCI8Stmt) Exec(args []driver.Value) (r driver.Result, err error) {
+	list := make([]namedValue, len(args))
+	for i, v := range args {
+		list[i] = namedValue{
+			Ordinal: i + 1,
+			Value:   v,
+		}
+	}
+	return s.exec(context.Background(), list)
+}
+
+func (s *OCI8Stmt) exec(ctx context.Context, args []namedValue) (r driver.Result, err error) {
+	var (
+		fbp []oci8bind
+	)
+
+	if fbp, err = s.bind(args); err != nil {
+		return nil, err
+	}
+
+	defer freeBoundParameters(fbp)
+
+	mode := C.ub4(C.OCI_DEFAULT)
+	if s.c.inTransaction == false {
+		mode = mode | C.OCI_COMMIT_ON_SUCCESS
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			// select again to avoid race condition if both are done
+			select {
+			case <-done:
+			default:
+				C.OCIBreak(
+					unsafe.Pointer(s.c.svc),
+					(*C.OCIError)(s.c.err))
+			}
+		}
+	}()
+
+	rv := C.OCIStmtExecute(
+		(*C.OCISvcCtx)(s.c.svc),
+		(*C.OCIStmt)(s.s),
+		(*C.OCIError)(s.c.err),
+		1,
+		0,
+		nil,
+		nil,
+		mode)
+	if rv != C.OCI_SUCCESS && rv != C.OCI_SUCCESS_WITH_INFO {
+		return nil, ociGetError(rv, s.c.err)
+	}
+
+	n, en := s.rowsAffected()
+	var id int64
+	var ei error
+	if n > 0 {
+		id, ei = s.lastInsertId()
+	}
+	outputBoundParameters(fbp)
+	return &OCI8Result{s: s, n: n, errn: en, id: id, errid: ei}, nil
+}
+
+type oci8col struct {
+	name string
+	kind C.ub2
+	size int
+	ind  *C.sb2
+	rlen *C.ub2
+	pbuf unsafe.Pointer
+}
+
+type oci8bind struct {
+	kind C.ub2
+	pbuf unsafe.Pointer
+	clen C.sb4
+	out  interface{} // original binded data type
+}
+
+type OCI8Rows struct {
+	s          *OCI8Stmt
+	cols       []oci8col
+	e          bool
+	indrlenptr unsafe.Pointer
+	closed     bool
+	done       chan struct{}
+	cls        bool
+}
+
+func freeDecriptor(p unsafe.Pointer, dtype C.ub4) {
+	tptr := *(*unsafe.Pointer)(p)
+	C.OCIDescriptorFree(unsafe.Pointer(tptr), dtype)
+}
+
+func (rc *OCI8Rows) Close() error {
+	if rc.closed {
+		return nil
+	}
+	rc.closed = true
+
+	close(rc.done)
+
+	if rc.cls {
+		rc.s.Close()
+	}
+
+	C.free(rc.indrlenptr)
+	for _, col := range rc.cols {
+		switch col.kind {
+		case C.SQLT_CLOB, C.SQLT_BLOB:
+			freeDecriptor(col.pbuf, C.OCI_DTYPE_LOB)
+		case C.SQLT_TIMESTAMP:
+			freeDecriptor(col.pbuf, C.OCI_DTYPE_TIMESTAMP)
+		case C.SQLT_TIMESTAMP_TZ:
+			freeDecriptor(col.pbuf, C.OCI_DTYPE_TIMESTAMP_TZ)
+		case C.SQLT_INTERVAL_DS:
+			freeDecriptor(col.pbuf, C.OCI_DTYPE_INTERVAL_DS)
+		case C.SQLT_INTERVAL_YM:
+			freeDecriptor(col.pbuf, C.OCI_DTYPE_INTERVAL_YM)
+		default:
+			C.free(col.pbuf)
+		}
+		col.pbuf = nil
+	}
+	return nil
+}
+
+func (rc *OCI8Rows) Columns() []string {
+	cols := make([]string, len(rc.cols))
+	for i, col := range rc.cols {
+		cols[i] = col.name
+	}
+	return cols
+}
+
+func (rc *OCI8Rows) Next(dest []driver.Value) (err error) {
+	if rc.closed {
+		return nil
+	}
+
+	rv := C.OCIStmtFetch2(
+		(*C.OCIStmt)(rc.s.s),
+		(*C.OCIError)(rc.s.c.err),
+		1,
+		C.OCI_FETCH_NEXT,
+		0,
+		C.OCI_DEFAULT)
+
+	if rv == C.OCI_NO_DATA {
+		return io.EOF
+	} else if rv != C.OCI_SUCCESS && rv != C.OCI_SUCCESS_WITH_INFO {
+		return ociGetError(rv, rc.s.c.err)
+	}
+
+	for i := range dest {
+		// TODO: switch rc.cols[i].ind
+		if *rc.cols[i].ind == -1 { // Null
+			dest[i] = nil
+			continue
+		} else if *rc.cols[i].ind != 0 {
+			return errors.New(fmt.Sprintf("Unknown column indicator: %d, col %s", rc.cols[i].ind, rc.cols[i].name))
+		}
+
+		switch rc.cols[i].kind {
+		case C.SQLT_DAT: // for test, date are return as timestamp
+			buf := (*[1 << 30]byte)(rc.cols[i].pbuf)[0:*rc.cols[i].rlen]
+			// TODO: Handle BCE dates (http://docs.oracle.com/cd/B12037_01/appdev.101/b10779/oci03typ.htm#438305)
+			// TODO: Handle timezones (http://docs.oracle.com/cd/B12037_01/appdev.101/b10779/oci03typ.htm#443601)
+			dest[i] = time.Date(
+				(int(buf[0])-100)*100+(int(buf[1])-100),
+				time.Month(int(buf[2])),
+				int(buf[3]),
+				int(buf[4])-1,
+				int(buf[5])-1,
+				int(buf[6])-1,
+				0,
+				rc.s.c.location)
+		case C.SQLT_BLOB, C.SQLT_CLOB:
+			ptmp := unsafe.Pointer(uintptr(rc.cols[i].pbuf) + unsafe.Sizeof(unsafe.Pointer(nil)))
+			bamt := (*C.ub4)(ptmp)
+			ptmp = unsafe.Pointer(uintptr(rc.cols[i].pbuf) + unsafe.Sizeof(C.ub4(0)) + unsafe.Sizeof(unsafe.Pointer(nil)))
+			b := (*[1 << 30]byte)(ptmp)[0:blobBufSize]
+			var buf []byte
+		again:
+			*bamt = 0
+			rv = C.OCILobRead(
+				(*C.OCISvcCtx)(rc.s.c.svc),
+				(*C.OCIError)(rc.s.c.err),
+				*(**C.OCILobLocator)(rc.cols[i].pbuf),
+				bamt,
+				1,
+				ptmp,
+				C.ub4(blobBufSize),
+				nil,
+				nil,
+				0,
+				C.SQLCS_IMPLICIT)
+			if rv == C.OCI_NEED_DATA {
+				buf = append(buf, b[:int(*bamt)]...)
+				goto again
+			}
+			if rv != C.OCI_SUCCESS {
+				return ociGetError(rv, rc.s.c.err)
+			}
+			if rc.cols[i].kind == C.SQLT_BLOB {
+				dest[i] = append(buf, b[:int(*bamt)]...)
+			} else {
+				dest[i] = string(append(buf, b[:int(*bamt)]...))
+			}
+		case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_AVC:
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
+			switch {
+			case *rc.cols[i].ind == 0: // Normal
+				dest[i] = string(buf)
+			case *rc.cols[i].ind == -2 || // Field longer than type (truncated)
+				*rc.cols[i].ind > 0: // Field longer than type (truncated). Value is original length.
+				dest[i] = string(buf)
+			default:
+				return errors.New(fmt.Sprintf("Unknown column indicator: %d", rc.cols[i].ind))
+			}
+		case C.SQLT_BIN: // RAW
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
+			dest[i] = buf
+		case C.SQLT_NUM: // NUMBER
+			buf := (*[21]byte)(unsafe.Pointer(rc.cols[i].pbuf))
+			dest[i] = buf
+		case C.SQLT_VNU: // VARNUM
+			buf := (*[22]byte)(unsafe.Pointer(rc.cols[i].pbuf))
+			dest[i] = buf
+		case C.SQLT_INT: // INT
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
+			dest[i] = buf
+		case C.SQLT_LNG: // LONG
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
+			dest[i] = buf
+		case C.SQLT_IBDOUBLE, C.SQLT_IBFLOAT:
+			colsize := rc.cols[i].size
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:colsize]
+			if colsize == 4 {
+				v := uint32(buf[3])
+				v |= uint32(buf[2]) << 8
+				v |= uint32(buf[1]) << 16
+				v |= uint32(buf[0]) << 24
+
+				// Don't know why bits are inverted that way, but it works
+				if buf[0]&0x80 == 0 {
+					v ^= 0xffffffff
+				} else {
+					v &= 0x7fffffff
+				}
+				dest[i] = math.Float32frombits(v)
+			} else if colsize == 8 {
+				v := uint64(buf[7])
+				v |= uint64(buf[6]) << 8
+				v |= uint64(buf[5]) << 16
+				v |= uint64(buf[4]) << 24
+				v |= uint64(buf[3]) << 32
+				v |= uint64(buf[2]) << 40
+				v |= uint64(buf[1]) << 48
+				v |= uint64(buf[0]) << 56
+
+				// Don't know why bits are inverted that way, but it works
+				if buf[0]&0x80 == 0 {
+					v ^= 0xffffffffffffffff
+				} else {
+					v &= 0x7fffffffffffffff
+				}
+
+				dest[i] = math.Float64frombits(v)
+			} else {
+				return errors.New(fmt.Sprintf("Unhandled binary float size: %d", colsize))
+			}
+		case C.SQLT_TIMESTAMP:
+			if rv := C.WrapOCIDateTimeGetDateTime(
+				(*C.OCIEnv)(rc.s.c.env),
+				(*C.OCIError)(rc.s.c.err),
+				*(**C.OCIDateTime)(rc.cols[i].pbuf),
+			); rv.rv != C.OCI_SUCCESS {
+				return ociGetError(rv.rv, rc.s.c.err)
+			} else {
+				dest[i] = time.Date(
+					int(rv.y),
+					time.Month(rv.m),
+					int(rv.d),
+					int(rv.hh),
+					int(rv.mm),
+					int(rv.ss),
+					int(rv.ff),
+					rc.s.c.location)
+			}
+		case C.SQLT_TIMESTAMP_TZ, C.SQLT_TIMESTAMP_LTZ:
+			tptr := *(**C.OCIDateTime)(rc.cols[i].pbuf)
+			rv := C.WrapOCIDateTimeGetDateTime(
+				(*C.OCIEnv)(rc.s.c.env),
+				(*C.OCIError)(rc.s.c.err),
+				tptr)
+			if rv.rv != C.OCI_SUCCESS {
+				return ociGetError(rv.rv, rc.s.c.err)
+			}
+			rvz := C.WrapOCIDateTimeGetTimeZoneNameOffset(
+				(*C.OCIEnv)(rc.s.c.env),
+				(*C.OCIError)(rc.s.c.err),
+				tptr)
+			if rvz.rv != C.OCI_SUCCESS {
+				return ociGetError(rvz.rv, rc.s.c.err)
+			}
+			nnn := C.GoStringN((*C.char)((unsafe.Pointer)(&rvz.zone[0])), C.int(rvz.zlen))
+			loc, err := time.LoadLocation(nnn)
+			if err != nil {
+				// TODO: reuse locations
+				loc = time.FixedZone(nnn, int(rvz.h)*60*60+int(rvz.m)*60)
+			}
+			dest[i] = time.Date(
+				int(rv.y),
+				time.Month(rv.m),
+				int(rv.d),
+				int(rv.hh),
+				int(rv.mm),
+				int(rv.ss),
+				int(rv.ff),
+				loc)
+		case C.SQLT_INTERVAL_DS:
+			iptr := *(**C.OCIInterval)(rc.cols[i].pbuf)
+			rv := C.WrapOCIIntervalGetDaySecond(
+				(*C.OCIEnv)(rc.s.c.env),
+				(*C.OCIError)(rc.s.c.err),
+				iptr)
+			if rv.rv != C.OCI_SUCCESS {
+				return ociGetError(rv.rv, rc.s.c.err)
+			}
+			dest[i] = int64(time.Duration(rv.d)*time.Hour*24 + time.Duration(rv.hh)*time.Hour + time.Duration(rv.mm)*time.Minute + time.Duration(rv.ss)*time.Second + time.Duration(rv.ff))
+		case C.SQLT_INTERVAL_YM:
+			iptr := *(**C.OCIInterval)(rc.cols[i].pbuf)
+			rv := C.WrapOCIIntervalGetYearMonth(
+				(*C.OCIEnv)(rc.s.c.env),
+				(*C.OCIError)(rc.s.c.err),
+				iptr)
+			if rv.rv != C.OCI_SUCCESS {
+				return ociGetError(rv.rv, rc.s.c.err)
+			}
+			dest[i] = int64(rv.y)*12 + int64(rv.m)
+		default:
+			return errors.New(fmt.Sprintf("Unhandled column type: %d", rc.cols[i].kind))
+		}
+	}
+
+	return nil
+}
+
+func ociGetErrorS(err unsafe.Pointer) error {
+	rv := C.WrapOCIErrorGet((*C.OCIError)(err))
+	s := C.GoString(&rv.err[0])
+	if isBadConnection(s) {
+		return driver.ErrBadConn
+	}
+	return errors.New(s)
+}
+
+func isBadConnection(error string) bool {
+	if len(error) <= 8 {
+		return false
+	}
+	errorCode := error[0:9]
+	for _, badConnCode := range badConnCodes {
+		if badConnCode == errorCode {
+			return true
+		}
+	}
+	return false
+}
+
+func ociGetError(rv C.sword, err unsafe.Pointer) error {
+	switch rv {
+	case C.OCI_INVALID_HANDLE:
+		return errors.New("OCI_INVALID_HANDLE")
+	case C.OCI_SUCCESS_WITH_INFO:
+		return errors.New("OCI_SUCCESS_WITH_INFO")
+	case C.OCI_RESERVED_FOR_INT_USE:
+		return errors.New("OCI_RESERVED_FOR_INT_USE")
+	case C.OCI_NO_DATA:
+		return errors.New("OCI_NO_DATA")
+	case C.OCI_NEED_DATA:
+		return errors.New("OCI_NEED_DATA")
+	case C.OCI_STILL_EXECUTING:
+		return errors.New("OCI_STILL_EXECUTING")
+	case C.OCI_SUCCESS:
+		panic("ociGetError called with no error")
+	case C.OCI_ERROR:
+		return ociGetErrorS(err)
+	}
+	return fmt.Errorf("oracle return error code %d", rv)
+}
+
+func CByte(b []byte) *C.char {
+	p := C.malloc(C.size_t(len(b)))
+	pp := (*[1 << 30]byte)(p)
+	copy(pp[:], b)
+	return (*C.char)(p)
+}
+
+var phre = regexp.MustCompile(`\?`)
+
+// converts "?" characters to  :1, :2, ... :n
+func placeholders(sql string) string {
+	n := 0
+	return phre.ReplaceAllStringFunc(sql, func(string) string {
+		n++
+		return ":" + strconv.Itoa(n)
+	})
+}
+
+// ColumnTypeDatabaseTypeName implement RowsColumnTypeDatabaseTypeName.
+func (rc *OCI8Rows) ColumnTypeDatabaseTypeName(i int) string {
+	var p unsafe.Pointer
+	var tp C.ub2
+
+	rp := C.WrapOCIParamGet(rc.s.s, C.OCI_HTYPE_STMT, (*C.OCIError)(rc.s.c.err), C.ub4(i+1))
+	if rp.rv == C.OCI_SUCCESS {
+		p = rp.ptr
+	}
+
+	tpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_TYPE, (*C.OCIError)(rc.s.c.err))
+	if tpr.rv == C.OCI_SUCCESS {
+		tp = tpr.num
+	}
+
+	switch tp {
+	case C.SQLT_CHR:
+		return "SQLT_CHR"
+	case C.SQLT_NUM:
+		return "SQLT_NUM"
+	case C.SQLT_INT:
+		return "SQLT_INT"
+	case C.SQLT_FLT:
+		return "SQLT_FLT"
+	case C.SQLT_STR:
+		return "SQLT_STR"
+	case C.SQLT_VNU:
+		return "SQLT_VNU"
+	case C.SQLT_LNG:
+		return "SQLT_LNG"
+	case C.SQLT_VCS:
+		return "SQLT_VCS"
+	case C.SQLT_DAT:
+		return "SQLT_DAT"
+	case C.SQLT_VBI:
+		return "SQLT_VBI"
+	case C.SQLT_BFLOAT:
+		return "SQLT_BFLOAT"
+	case C.SQLT_BDOUBLE:
+		return "SQLT_BDOUBLE"
+	case C.SQLT_BIN:
+		return "SQLT_BIN"
+	case C.SQLT_LBI:
+		return "SQLT_LBI"
+	case C.SQLT_UIN:
+		return "SQLT_UIN"
+	case C.SQLT_LVC:
+		return "SQLT_LVC"
+	case C.SQLT_LVB:
+		return "SQLT_LVB"
+	case C.SQLT_AFC:
+		return "SQLT_AFC"
+	case C.SQLT_AVC:
+		return "SQLT_AVC"
+	case C.SQLT_RDD:
+		return "SQLT_RDD"
+	case C.SQLT_NTY:
+		return "SQLT_NTY"
+	case C.SQLT_REF:
+		return "SQLT_REF"
+	case C.SQLT_CLOB:
+		return "SQLT_CLOB"
+	case C.SQLT_BLOB:
+		return "SQLT_BLOB"
+	case C.SQLT_FILE:
+		return "SQLT_FILE"
+	case C.SQLT_VST:
+		return "SQLT_VST"
+	case C.SQLT_ODT:
+		return "SQLT_ODT"
+	case C.SQLT_DATE:
+		return "SQLT_DATE"
+	case C.SQLT_TIMESTAMP:
+		return "SQLT_TIMESTAMP"
+	case C.SQLT_TIMESTAMP_TZ:
+		return "SQLT_TIMESTAMP_TZ"
+	case C.SQLT_INTERVAL_YM:
+		return "SQLT_INTERVAL_YM"
+	case C.SQLT_INTERVAL_DS:
+		return "SQLT_INTERVAL_DS"
+	case C.SQLT_TIMESTAMP_LTZ:
+		return "SQLT_TIMESTAMP_LTZ"
+	}
+	return ""
+}
+
+func (rc *OCI8Rows) ColumnTypeLength(i int) (length int64, ok bool) {
+	var p unsafe.Pointer
+	var lp C.ub2
+
+	rp := C.WrapOCIParamGet(rc.s.s, C.OCI_HTYPE_STMT, (*C.OCIError)(rc.s.c.err), C.ub4(i+1))
+	if rp.rv != C.OCI_SUCCESS {
+		return 0, false
+	}
+	p = rp.ptr
+
+	lpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_SIZE, (*C.OCIError)(rc.s.c.err))
+	if lpr.rv != C.OCI_SUCCESS {
+		return 0, false
+	}
+	lp = lpr.num
+
+	return int64(lp), true
+}
+
+/*
+func (rc *OCI8Rows) ColumnTypePrecisionScale(i int) (precision, scale int64, ok bool) {
+	return 0, 0, false
+}
+*/
+
+// ColumnTypeNullable implement RowsColumnTypeNullable.
+func (rc *OCI8Rows) ColumnTypeNullable(i int) (nullable, ok bool) {
+	retUb4 := C.WrapOCIAttrGetUb4(rc.s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_IS_NULL, (*C.OCIError)(rc.s.c.err))
+	if retUb4.rv != C.OCI_SUCCESS {
+		return false, false
+	}
+	return retUb4.num != 0, true
+}
+
+// ColumnTypeScanType implement RowsColumnTypeScanType.
+func (rc *OCI8Rows) ColumnTypeScanType(i int) reflect.Type {
+	var p unsafe.Pointer
+	var tp C.ub2
+
+	tpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_TYPE, (*C.OCIError)(rc.s.c.err))
+	if tpr.rv == C.OCI_SUCCESS {
+		tp = tpr.num
+	}
+
+	switch tp {
+	case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_VCS, C.SQLT_AVC:
+		return reflect.SliceOf(reflect.TypeOf(""))
+	case C.SQLT_BIN:
+		return reflect.SliceOf(reflect.TypeOf(byte(0)))
+	case C.SQLT_NUM:
+		return reflect.TypeOf(int64(0))
+	case C.SQLT_IBDOUBLE, C.SQLT_IBFLOAT:
+		return reflect.TypeOf(float64(0))
+	case C.SQLT_CLOB, C.SQLT_BLOB:
+		return reflect.SliceOf(reflect.TypeOf(byte(0)))
+	case C.SQLT_TIMESTAMP, C.SQLT_DAT:
+		return reflect.TypeOf(time.Time{})
+	case C.SQLT_TIMESTAMP_TZ, C.SQLT_TIMESTAMP_LTZ:
+		return reflect.TypeOf(time.Time{})
+	case C.SQLT_INTERVAL_DS:
+		return reflect.TypeOf(time.Duration(0))
+	case C.SQLT_INTERVAL_YM:
+		return reflect.TypeOf(time.Duration(0))
+	case C.SQLT_RDD: // rowid
+		return reflect.SliceOf(reflect.TypeOf(""))
+	default:
+		return reflect.SliceOf(reflect.TypeOf(""))
+	}
+	return reflect.SliceOf(reflect.TypeOf(byte(0)))
+}

--- a/vendor/github.com/mattn/go-oci8/oci8.pc
+++ b/vendor/github.com/mattn/go-oci8/oci8.pc
@@ -1,0 +1,9 @@
+prefix=/usr
+includedir=${prefix}/include/oracle/12.1/client64
+libdir=${prefix}/lib/oracle/12.1/client64/lib
+
+Name: oci8
+Description: Oracle Instant Client
+Version: 12.1
+Cflags: -I${includedir}
+Libs: -L${libdir} -lclntsh

--- a/vendor/github.com/mattn/go-oci8/oci8_go18.go
+++ b/vendor/github.com/mattn/go-oci8/oci8_go18.go
@@ -1,0 +1,82 @@
+// +build go1.8
+
+package oci8
+
+import (
+	"database/sql/driver"
+
+	"context"
+)
+
+// Ping implement Pinger.
+func (c *OCI8Conn) Ping(ctx context.Context) error {
+	return c.ping(ctx)
+}
+
+func toNamedValue(nv driver.NamedValue) namedValue {
+	mv := namedValue(nv)
+	// FIXME
+	// This is my fault that I've add code using sql.Out until next release.
+	//if out, ok := mv.Value.(sql.Out); ok {
+	//	mv.Value = outValue{Dest: out.Dest, In: out.In}
+	//}
+	return mv
+}
+
+// QueryContext implement QueryerContext.
+func (c *OCI8Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	list := make([]namedValue, len(args))
+	for i, nv := range args {
+		list[i] = toNamedValue(nv)
+	}
+	return c.query(ctx, query, list)
+}
+
+// ExecContext implement ExecerContext.
+func (c *OCI8Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	list := make([]namedValue, len(args))
+	for i, nv := range args {
+		list[i] = toNamedValue(nv)
+	}
+	return c.exec(ctx, query, list)
+}
+
+// PrepareContext implement ConnPrepareContext.
+func (c *OCI8Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return c.prepare(ctx, query)
+}
+
+// BeginTx implement ConnBeginTx.
+func (c *OCI8Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return c.begin(ctx)
+}
+
+// QueryContext implement QueryerContext.
+func (s *OCI8Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	list := make([]namedValue, len(args))
+	for i, nv := range args {
+		list[i] = toNamedValue(nv)
+	}
+	return s.query(ctx, list)
+}
+
+// ExecContext implement ExecerContext.
+func (s *OCI8Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	list := make([]namedValue, len(args))
+	for i, nv := range args {
+		list[i] = toNamedValue(nv)
+	}
+	return s.exec(ctx, list)
+}
+
+/* FIXME
+This is my fault that I've add code using sql.Out until next release.
+func (c *OCI8Conn) CheckNamedValue(nv *driver.NamedValue) error {
+	switch nv.Value.(type) {
+	default:
+		return driver.ErrSkip
+	case sql.Out:
+		return nil
+	}
+}
+*/

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -103,6 +103,12 @@
 			"revisionTime": "2016-08-31T22:25:20Z"
 		},
 		{
+			"checksumSHA1": "xXHmjFcWfeR8GJVhQKoYUAwTFB4=",
+			"path": "github.com/mattn/go-oci8",
+			"revision": "73e70e9fc52baed56e26e53fb22c21a913e69490",
+			"revisionTime": "2017-11-02T03:04:57Z"
+		},
+		{
 			"checksumSHA1": "bKMZjd2wPw13VwoE7mBeSv5djFA=",
 			"origin": "jus.tw.cx/jw-prom-sql-exporter/vendor/github.com/matttproud/golang_protobuf_extensions/pbutil",
 			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
@@ -191,5 +197,5 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
-	"rootPath": "github.com/justwatchcom/sql_exporter"
+	"rootPath": "github.com/mkosiorek/sql_exporter"
 }


### PR DESCRIPTION
The exporter needs support for additional databases - Oracle. I have added the support for the [oci8](https://github.com/mattn/go-oci8) driver.
With given changes after updating the connection URL and query, exporter works smoothly.

Currently, the metrics and errors contain data like driver, host, database and user what is a cause of vulnerability - sensitive data like those must be protected and cannot be exposed outside the application.