### PR TITLE
Add parameter startup_sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ jobs:
   # each query will be executed on each connection
   connections:
   - 'postgres://postgres@localhost/postgres?sslmode=disable'
+  # startup_sql is an array of SQL statements
+  # each statements is executed once after connecting
+  startup_sql:
+  - 'SET lock_timeout = 1000'
+  - 'SET idle_in_transaction_session_timeout = 100'
   # queries is a map of Metric/Query mappings
   queries:
     # name is prefied with sql_ and used as the metric name

--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type Job struct {
 	Interval    time.Duration `yaml:"interval"`  // interval at which this job is run
 	Connections []string      `yaml:"connections"`
 	Queries     []*Query      `yaml:"queries"`
+	StartupSQL  []string      `yaml:"startup_sql"` // SQL executed on startup
 }
 
 type connection struct {

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -4,6 +4,9 @@ jobs:
   interval: '5m'
   connections:
   - 'postgres://postgres@localhost/postgres?sslmode=disable'
+  startup_sql:
+  - 'SET lock_timeout = 1000'
+  - 'SET idle_in_transaction_session_timeout = 100'
   queries:
   - name: "running_queries"
     help: "Number of running queries"
@@ -31,7 +34,7 @@ jobs:
     values:
       - "replication_lag"
     query:  |
-            WITH lag AS ( 
+            WITH lag AS (
             SELECT
             CASE
             WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0


### PR DESCRIPTION
I added a new parameter: _startup_sql_.
_startup_sql_ is an array of SQL statements, each statements is executed once after connecting.
This is useful to set parameters or do preparation work for the monitoring.
