### PR TITLE
Added a short description how to create an installer executable for Windows including example config for MSSQL metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ environment.
 LOGLEVEL=info ./sql_exporter
 ```
 
+
+Additional documentation
+========================
+
+Like creating a windows installer for exporting MSSQL metrics can be found in the doc directory.
+
+
 Why this exporter exists
 ========================
 

--- a/doc/Create-Windows-Installer.md
+++ b/doc/Create-Windows-Installer.md
@@ -1,0 +1,63 @@
+# How to create a windows installer 
+
+## Overview
+
+This describes how to create an EXE-Installer for Windows of the
+sql_exporter. 
+
+You can use the sql_exporter to export metrics of an MSSQL-server. The
+corresponding installer will copy the files to the correct program
+directory (%PROGRAMFILES%\sql_exporter), register the program via NSSM
+(see below) as a windows service and it will open the Windows Firewall
+for the corresponding port (9237/tcp).
+
+Additional uninstall information will be created.
+
+You will need additional software to create the Installer-EXE.
+
+
+## Quick steps
+
+- Get NSIS from http://nsis.sourceforge.net/Main_Page
+- Compile the sql_exporter to match the Windows platform (cross compile or compile native under windows)
+- Get NSSM - the Non-Sucking Service Manager from http://nssm.cc/
+- Compile the NSIS script 
+- Use the resulting sql_exporter_setup.exe to deploy the sql_exporter to you Windows hosts.
+
+
+## Long description
+
+### Requirements
+
+- NSIS from http://nsis.sourceforge.net/Main_Page
+- Compile the sql_exporter to match the Windows platform (cross compile or compile native under windows)
+- NSSM - the Non-Sucking Service Manager from http://nssm.cc/ (archiv)
+
+
+### Directory structure
+
+This layout is based on drive D:\. Adopt this configuration or change the corresponding pathes in the NSIS script.
+
+Path / File | Description
+------------|------------
+d:\sql_exporter\sql_exporter.exe | binary of the exporter
+d:\sql_exporter\config.yml | example configuration (take a look at examples/config/mssql_config.yml)
+d:\sql_exporter\source | place the source code of the used sql_exporter here
+d:\sql_exporter\supplementals\sql_exporter.nsi | NSIS script for create the Installer-EXE
+
+
+Extract NSSM to D:\sql_exporter\supplementals\nssm:
+
+Path / File | Description | External source
+------------|-------------|---------------- 
+d:\sql_exporter\supplementals\nssm | extract NSSM to this directory | NSSM
+d:\sql_exporter\supplementals\nssm\source | Source code of NSSM | NSSM
+d:\sql_exporter\supplementals\nssm\win32\ | NSSM 32 bit | NSSM
+d:\sql_exporter\supplementals\nssm\win64\ | NSSM 64 bit | NSSM
+
+
+### Create the Installer
+
+Just right click on D:\sql_exporter\supplementals\sql_exporter.nsi and
+chose "Compile NSIS script" after installing NSIS. The script will
+create the file D:\sql_exporter\supplementals\sql_exporter_setup.exe.

--- a/examples/config/mssql_config.yml
+++ b/examples/config/mssql_config.yml
@@ -1,0 +1,24 @@
+jobs:
+- connections:
+  - sqlserver://<USERNAME>:<PASSWORD>@127.0.0.1:1433
+  interval: '0'
+  name: cluster
+  queries:
+  - help: Number of running queries
+    labels:
+    - mylabel
+    name: running_queries
+    query: "SELECT 1 as foobar, 'test' as mylabel"
+    values:
+    - foobar
+
+  - help: 'Number of times the transaction log has been expanded, per database.'
+    labels:
+      - db
+    name: mssql_log_growths
+    query: |
+      SELECT rtrim(instance_name) AS db, cntr_value
+      FROM sys.dm_os_performance_counters WITH (NOLOCK)
+      WHERE counter_name = 'Log Growths' AND instance_name <> '_Total'
+    values: 
+    - cntr_value

--- a/supplementals/sql_exporter.nsi
+++ b/supplementals/sql_exporter.nsi
@@ -17,7 +17,7 @@ LoadLanguageFile "${NSISDIR}\Contrib\Language files\English.nlf"
 ;Version Information
 VIProductVersion "${INSTALLERVERSION}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "SQL Exporter"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "credativ GmbH"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "<Your company>"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "Prometheus SQL exporter for SQL metrics"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "sql_exporter_setup"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VERSION}"

--- a/supplementals/sql_exporter.nsi
+++ b/supplementals/sql_exporter.nsi
@@ -1,0 +1,74 @@
+Name "SQL Exporter"
+!define VERSION "98cffbac477fc532cb3bdab76709cd0dafce34f5"  ;git tag
+!define INSTALLERVERSION "1.0.0.0"
+!define DESCRIPTION "prometheus sql exporter for sql metrics"
+OutFile "d:\sql_exporter_setup.exe"
+!define _FWPORT "9237"
+
+InstallDir $PROGRAMFILES64\sql_exporter
+
+Page directory
+Page instfiles
+UninstPage uninstConfirm
+UninstPage instfiles
+
+
+LoadLanguageFile "${NSISDIR}\Contrib\Language files\English.nlf"
+;Version Information
+VIProductVersion "${INSTALLERVERSION}"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "SQL Exporter"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "credativ GmbH"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "Prometheus SQL exporter for SQL metrics"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "sql_exporter_setup"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VERSION}"
+
+
+;Installation
+Section ""
+  ; install destination
+  SetOutPath "$PROGRAMFILES64\sql_exporter"
+
+  ; include all files from this directory
+  File /R "d:\sql_exporter\*.*"
+  
+  ; create uninstaller
+  WriteUninstaller $INSTDIR\uninstall.exe
+
+  ; open the firewall port
+  DetailPrint "Opening ${_FWPORT}/tcp for inbound connections.."
+  ExecWait 'netsh advfirewall firewall add rule name="sql_exporter" protocol=TCP dir=in localport=${_FWPORT} action=allow'  
+
+  ; service registering
+  DetailPrint "Registering and starting service via nssm.."
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe install sql_exporter "$PROGRAMFILES64\sql_exporter\sql_exporter.exe"'
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe set sql_exporter Description "Prometheus sql_exporter for sql metrics"'
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe set sql_exporter DisplayName "SQL Exporter"'
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe start sql_exporter'
+
+  ; add entry to Add/Remove Programs control panel
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter" "DisplayName" "sql_exporter"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter" "DisplayVersion" "${VERSION} x64 64Bit"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter" "Publisher" "credativ GmbH"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter" "UninstallString" "$PROGRAMFILES64\sql_exporter\uninstall.exe"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter" "QuietUninstallString" "$PROGRAMFILES64\sql_exporter\uninstall.exe"
+
+SectionEnd
+
+; Uninstall
+Section "Uninstall"
+  ; service registering
+  DetailPrint 'Removing service..'
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe stop sql_exporter'
+  ExecWait '$PROGRAMFILES64\sql_exporter\supplementals\nssm\win64\nssm.exe remove sql_exporter confirm'
+
+  ; close the firewall port
+  DetailPrint "Closing ${_FWPORT}/tcp for inbound connections.."
+  ExecWait 'netsh advfirewall firewall del rule name="sql_exporter" protocol=TCP dir=in localport=${_FWPORT}'  
+
+  ; remove all files
+  RMDir /r $INSTDIR
+  
+  ; delete the Registry Key 
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\sql_exporter"
+
+SectionEnd


### PR DESCRIPTION
Added a short description how to create an installer executable for Windows.

This installer contains:

copying the (not included sql_exporter.exe) and dependencies to %PROGRAMFILES%\sql_exporter
registering a service for the sql_exporter via nssm
opening the Windows Firewall to allow incoming connections on 9237/tcp
uninstall information to remove the program and the servicem, including closing the firewall ports
The neccessary NSIS script (compile script for creating the exe) has been included.
A sample config to access an installed MSSQL and exporting metrics can be found in examples/config/mssql_config.yml.

The exe installer makes use of two external dependencies (NSIS and NSSM) which are not included. Links can be found in the doc.