### PR TITLE
feat: added execution time range support for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ jobs:
 - name: "example"
   # interval defined the pause between the runs of this job
   interval: '5m'
+  # execution_time_from defines optional lower boundary of time interval the query will be executed
+  # it is defined in format hh:mm:ss and default is 00:00:00 in UTC
+  execution_time_from: '12:00:00'
+  # execution_time_to defines optional upper boundary of time interval the query will be executed
+  # it is defined in format hh:mm:ss and default is 24:00:00 in UTC
+  execution_time_to: '14:00:00'
   # connections is an array of connection URLs
   # each query will be executed on each connection
   connections:

--- a/config.go
+++ b/config.go
@@ -10,8 +10,12 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v2"
+
+	yaml "gopkg.in/yaml.v2"
+	//"github.com/ghodss/yaml"
 )
+
+const TimeFormat = "15:04:05"
 
 // Read attempts to parse the given config and return a file
 // object
@@ -43,14 +47,16 @@ type File struct {
 
 // Job is a collection of connections and queries
 type Job struct {
-	log         log.Logger
-	conns       []*connection
-	Name        string        `yaml:"name"`      // name of this job
-	KeepAlive   bool          `yaml:"keepalive"` // keep connection between runs?
-	Interval    time.Duration `yaml:"interval"`  // interval at which this job is run
-	Connections []string      `yaml:"connections"`
-	Queries     []*Query      `yaml:"queries"`
-	StartupSQL  []string      `yaml:"startup_sql"` // SQL executed on startup
+	log               log.Logger
+	conns             []*connection
+	Name              string        `yaml:"name"`      // name of this job
+	KeepAlive         bool          `yaml:"keepalive"` // keep connection between runs?
+	Interval          time.Duration `yaml:"interval"`  // interval at which this job is run
+	ExecutionTimeFrom TimeOfDay     `yaml:"execution_time_from"`
+	ExecutionTimeTo   TimeOfDay     `yaml:"execution_time_to"`
+	Connections       []string      `yaml:"connections"`
+	Queries           []*Query      `yaml:"queries"`
+	StartupSQL        []string      `yaml:"startup_sql"` // SQL executed on startup
 }
 
 type connection struct {
@@ -74,4 +80,34 @@ type Query struct {
 	Values   []string `yaml:"values"`    // expose each of these as an gauge
 	Query    string   `yaml:"query"`     // a literal query
 	QueryRef string   `yaml:"query_ref"` // references an query in the query map
+}
+
+// TimeOfDay wrapper for time.Time. It implements the yaml.Unmarshaler interface.
+type TimeOfDay struct {
+	time.Time
+}
+
+// UnmarshalYAML allows unmarshalling of time.Time from YAML with custom time format.
+func (t *TimeOfDay) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var (
+		s   string
+		err error
+	)
+	err = unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	t.Time, err = time.ParseInLocation(TimeFormat, s, time.UTC)
+	if err != nil {
+		return err
+	}
+	// zero time in time package is year 1 but parse time without year gives year 0
+	// so we need to add 1 year to be consistent
+	t.Time = t.Time.AddDate(1, 0, 0)
+	return nil
+}
+
+// GetTime returns wrapped time.Time
+func (t *TimeOfDay) GetTime() time.Time {
+	return t.Time
 }

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -2,6 +2,8 @@
 jobs:
 - name: "global"
   interval: '5m'
+  execution_time_from: '00:00:00'
+  execution_time_to: '23:59:59'
   connections:
   - 'postgres://postgres@localhost/postgres?sslmode=disable'
   startup_sql:


### PR DESCRIPTION
Hi, we came across situation when we want to run more complex queries which cannot run all day.
We might set the time interval to `24h` but we would like to run those queries at night (our system is locally based thus significantly lower traffic at night). With using interval, the time of execution is still dependent on the exporter start time.

So I decided to added possibility to specify `execution_time_from` and `execution_time_to` for each `job`. This still allows user to specify the `interval` but also restrict those execution to specified time window and otherwise skiping it.

I know this is definitely not ideal solution  by any means but we have also regularly running queries which fits this exporter and I didn't want to create new way of querying. 
This is optional feature which does not change the exporter behavior if not explicitly specified.

If you find this useful I'll be happy to avoid having own fork.
If you have other idea how to do this or change the way it's implemented I'll be happy to discuss it.

Thanks for considering in advance!