### PR TITLE
Do not attempt to parse MySQL DSNs as URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.13
   - tip
 
 script:

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/ioutil"
-	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -55,7 +54,7 @@ type Job struct {
 
 type connection struct {
 	conn     *sqlx.DB
-	url      *url.URL
+	url      string
 	driver   string
 	host     string
 	database string

--- a/job.go
+++ b/job.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/denisenkom/go-mssqldb" // register the MS-SQL driver
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	_ "github.com/go-sql-driver/mysql" // register the MySQL driver
+	"github.com/go-sql-driver/mysql" // register the MySQL driver
 	"github.com/jmoiron/sqlx"
 	_ "github.com/kshvakov/clickhouse" // register the ClickHouse driver
 	_ "github.com/lib/pq"              // register the PostgreSQL driver
@@ -85,6 +85,23 @@ func (j *Job) Run() {
 	// parse the connection URLs and create an connection object for each
 	if len(j.conns) < len(j.Connections) {
 		for _, conn := range j.Connections {
+			// MySQL DSNs do not parse cleanly as URLs as of Go 1.12.8+
+			if strings.HasPrefix(conn, "mysql://") {
+				config, err := mysql.ParseDSN(strings.TrimPrefix(conn, "mysql://"))
+				if err != nil {
+					level.Error(j.log).Log("msg", "Failed to parse MySQL DSN", "url", conn, "err", err)
+				}
+
+				j.conns = append(j.conns, &connection{
+					conn:     nil,
+					url:      conn,
+					driver:   "mysql",
+					host:     config.Addr,
+					database: config.DBName,
+					user:     config.User,
+				})
+				continue
+			}
 			u, err := url.Parse(conn)
 			if err != nil {
 				level.Error(j.log).Log("msg", "Failed to parse URL", "url", conn, "err", err)
@@ -98,7 +115,7 @@ func (j *Job) Run() {
 			// remember them
 			j.conns = append(j.conns, &connection{
 				conn:     nil,
-				url:      u,
+				url:      conn,
 				driver:   u.Scheme,
 				host:     u.Host,
 				database: strings.TrimPrefix(u.Path, "/"),
@@ -178,14 +195,14 @@ func (c *connection) connect(job *Job) error {
 	if c.conn != nil {
 		return nil
 	}
-	dsn := c.url.String()
-	switch c.url.Scheme {
+	dsn := c.url
+	switch c.driver {
 	case "mysql":
 		dsn = strings.TrimPrefix(dsn, "mysql://")
 	case "clickhouse":
 		dsn = "tcp://" + strings.TrimPrefix(dsn, "clickhouse://")
 	}
-	conn, err := sqlx.Connect(c.url.Scheme, dsn)
+	conn, err := sqlx.Connect(c.driver, dsn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
they do not conform to the RFCs for web URLs, and Go 1.12.8+ enforce
this.

Instead of the parsed URL, keep the original connection string.

This could probably be generalized for other databases, but I don't know
if they have the same problem.

Signed-off-by: Matthias Rampke <mr@soundcloud.com>