### PR TITLE
Log warning if column not found in query result

### DIFF
--- a/query.go
+++ b/query.go
@@ -125,6 +125,12 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 		default:
 			return nil, fmt.Errorf("Column '%s' must be type float, is '%T' (val: %s)", valueName, i, f)
 		}
+	} else {
+		level.Warn(q.log).Log(
+			"msg", "Column not found in query result",
+			"column", valueName,
+			"resultColumns", res,
+		)
 	}
 	// make space for all defined variable label columns and the "static" labels
 	// added below


### PR DESCRIPTION
Log a warning message if the column name from `values:` is not found in the query result.
This can happen for instance when the `values:` uses mixed case names and the db is PostgreSQL which converts the column names of the result to lower case unless they're quoted with `"`.

Example:
 `select count(*) as myCount from table` returns column name `mycount` in the result. 
If `values:` contains `myCount` the value of `sql_myCount` will be `0` without any indication of what the actual problem is.
The workaround is to use quotes, i.e. `select count(*) as "myCount" ...`.
