### PR TITLE
fix clickhouse v2 dsn

### DIFF
--- a/job.go
+++ b/job.go
@@ -259,8 +259,6 @@ func (c *connection) connect(job *Job) error {
 	switch c.driver {
 	case "mysql":
 		dsn = strings.TrimPrefix(dsn, "mysql://")
-	case "clickhouse":
-		dsn = "tcp://" + strings.TrimPrefix(dsn, "clickhouse://")
 	}
 	conn, err := sqlx.Connect(c.driver, dsn)
 	if err != nil {


### PR DESCRIPTION
The version 0.4.4 is not working for clickhouse anymore due to changes in the clickhouse v2 driver.

Previously the dsn was expected to start with tcp:// as seen in https://github.com/ClickHouse/clickhouse-go/tree/v1#dsn
But for v2 its clickhouse:// as seen here: https://github.com/ClickHouse/clickhouse-go/tree/v2#dsn

By removing this case statement it should work again with the v2 driver.

I was not able to test this because i had to build images etc. to run it in our test setup.
But according to the documentation i expect this to work.