### PR TITLE
Update example deployment from extensions/v1beta to apps/v1

### DIFF
--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -26,7 +26,7 @@ spec:
           value: /config/config.yml
         - name: PGPASSFILE
           value: /pgpass/pgpass
-        image: justwatch/prom-sql-exporter:latest
+        image: docker.io/justwatch/sql_exporter:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/kubernetes/deployment.yml
+++ b/examples/kubernetes/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prom-sql-exporter
@@ -9,6 +9,9 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: prom-sql-exporter
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Update example deployment from extensions/v1beta to apps/v1
  
The former was deprecated in Kubernetes 1.16 (mid-2019)
