### PR TITLE
feat: allow disable built in metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,10 +20,11 @@ func init() {
 
 func main() {
 	var (
-		showVersion   = flag.Bool("version", false, "Print version information.")
-		listenAddress = flag.String("web.listen-address", ":9237", "Address to listen on for web interface and telemetry.")
-		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-		configFile    = flag.String("config.file", os.Getenv("CONFIG"), "SQL Exporter configuration file name.")
+		showVersion    = flag.Bool("version", false, "Print version information.")
+		disableBuiltIn = flag.Bool("metrics.disable-built-in", false, "Disable the collection of built-in metrics (such as GC stats).")
+		listenAddress  = flag.String("web.listen-address", ":9237", "Address to listen on for web interface and telemetry.")
+		metricsPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+		configFile     = flag.String("config.file", os.Getenv("CONFIG"), "SQL Exporter configuration file name.")
 	)
 
 	flag.Parse()
@@ -59,6 +60,10 @@ func main() {
 	if err != nil {
 		level.Error(logger).Log("msg", "Error starting exporter", "err", err)
 		os.Exit(1)
+	}
+
+	if *disableBuiltIn {
+		prometheus.Unregister(prometheus.NewGoCollector())
 	}
 	prometheus.MustRegister(exporter)
 


### PR DESCRIPTION
This PR adds the `-metrics.disable-built-in` flag in order to disable the collection and export of built-in metrics, such as GC statistics.

In some cases this is desirable. In many cases I would suspect this would be a good default as in reality I am not concerned with how well the GC is working on a tiny app running SQL queries every few minutes.