### PR TITLE
Update compatible connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently supported:
 - MySQL
 - Snowflake
 - Vertica
+- Materialize
 
 
 What does it look like?


### PR DESCRIPTION
This PR adds Materialize to the list of supported Databases :)
[Materialize](https://materialize.com/) implements the PostgreSQL Wire Protocol (`postgres://..`), so the Postgres driver works well.