### PR TITLE
Build and publish image for linux/arm64 platforms

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -38,5 +38,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I'm getting the following error while trying to run this image on an arm64 machine:
```
 The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ```
 
 
 This PR should address this by publishing image for arm64 platforms too. 