### PR TITLE
pins alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /src
 RUN GOGC=off go build -mod=vendor -v -o /sql_exporter .
 
 # multistage
-FROM alpine:latest
+FROM alpine:3.18.3
 
 RUN apk --update upgrade && \
     apk add curl ca-certificates && \


### PR DESCRIPTION
Currently the latest docker image of sql_exporter is built with alpine 3.18.2 which has multiple critical security vulnerabilities (busybox, ssl_client). Pinning the alpine version to the latest 3.18 release fixes those vulnerabilities