### PR TITLE
config: add customizable metric name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ For a more realistic example please have a look at [examples/kubernetes/configma
 jobs:
   # each job needs a unique name, it's used for logging and as an default label
 - name: "example"
+  # prefix for all metric names; joined with Query name, separated by underscore.
+  # defaults to "sql". May be an empty string, which removes the name prefix and underscore entirely.
+  prefix: "pg"
   # interval defined the pause between the runs of this job
   interval: '5m'
   # cron_schedule when to execute the job in the standard CRON syntax
@@ -134,7 +137,7 @@ jobs:
   - 'SET idle_in_transaction_session_timeout = 100'
   # queries is a map of Metric/Query mappings
   queries:
-    # name is prefied with sql_ and used as the metric name
+    # name is prefixed with pg_ and used as the metric name; i.e. pg_running_queries
   - name: "running_queries"
     # help is a requirement of the Prometheus default registry, currently not
     # used by the Prometheus server. Important: Must be the same for all metrics

--- a/config.go
+++ b/config.go
@@ -124,15 +124,16 @@ func (c *cronConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Job is a collection of connections and queries
 type Job struct {
-	log          log.Logger
-	conns        []*connection
-	Name         string        `yaml:"name"`          // name of this job
-	KeepAlive    bool          `yaml:"keepalive"`     // keep connection between runs?
-	Interval     time.Duration `yaml:"interval"`      // interval at which this job is run
-	CronSchedule cronConfig    `yaml:"cron_schedule"` // if specified, the interval is ignored and the job will be executed at the specified time in CRON syntax
-	Connections  []string      `yaml:"connections"`
-	Queries      []*Query      `yaml:"queries"`
-	StartupSQL   []string      `yaml:"startup_sql"` // SQL executed on startup
+	log              log.Logger
+	conns            []*connection
+	Name             string        `yaml:"name"`          // name of this job
+	MetricNamePrefix *string       `yaml:"prefix"`        // optional prefix for all metric names, may be empty string
+	KeepAlive        bool          `yaml:"keepalive"`     // keep connection between runs?
+	Interval         time.Duration `yaml:"interval"`      // interval at which this job is run
+	CronSchedule     cronConfig    `yaml:"cron_schedule"` // if specified, the interval is ignored and the job will be executed at the specified time in CRON syntax
+	Connections      []string      `yaml:"connections"`
+	Queries          []*Query      `yaml:"queries"`
+	StartupSQL       []string      `yaml:"startup_sql"` // SQL executed on startup
 }
 
 type connection struct {
@@ -152,7 +153,7 @@ type Query struct {
 	metrics       map[*connection][]prometheus.Metric
 	jobName       string
 	AllowZeroRows bool     `yaml:"allow_zero_rows"`
-	Name          string   `yaml:"name"`      // the prometheus metric name
+	Name          string   `yaml:"name"`      // the prometheus metric name, prefixed with Job.MetricPrefix
 	Help          string   `yaml:"help"`      // the prometheus metric help text
 	Labels        []string `yaml:"labels"`    // expose these columns as labels per gauge
 	Values        []string `yaml:"values"`    // expose each of these as an gauge


### PR DESCRIPTION
Previously, the metric name was always the query name, prefixed with `sql_`. Now, that remains the behavior if a prefix is not provided in the job config. An empty string may explicitly be provided, in which case `sql_` is not prepended to the query name.