### PR TITLE
Skip metric update if no values are defined in configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,7 +53,7 @@ var (
 
 	// Those are the default buckets
 	DefaultQueryDurationHistogramBuckets = prometheus.DefBuckets
-	// To make the buckets configurable let's init it after loading the configuration.
+	// To make the buckets configurable lets init it after loading the configuration.
 	queryDurationHistogram *prometheus.HistogramVec
 )
 
@@ -174,8 +174,8 @@ type Query struct {
 	Name          string   `yaml:"name"`      // the prometheus metric name
 	Help          string   `yaml:"help"`      // the prometheus metric help text
 	Labels        []string `yaml:"labels"`    // expose these columns as labels per gauge
-	Values        []string `yaml:"values"`    // expose each of these as an gauge
+	Values        []string `yaml:"values"`    // expose each of these as a gauge
 	Timestamp     string   `yaml:"timestamp"` // expose as metric timestamp
 	Query         string   `yaml:"query"`     // a literal query
-	QueryRef      string   `yaml:"query_ref"` // references an query in the query map
+	QueryRef      string   `yaml:"query_ref"` // references a query in the query map
 }

--- a/query.go
+++ b/query.go
@@ -79,6 +79,11 @@ func (q *Query) Run(conn *connection) error {
 
 // updateMetrics parses the result set and returns a slice of const metrics
 func (q *Query) updateMetrics(conn *connection, res map[string]interface{}) ([]prometheus.Metric, error) {
+	// if no value were defined to be parsed, return immediately
+	if len(q.Values) == 0 {
+		level.Debug(q.log).Log("msg", "No values defined in configuration, skipping metric update")
+		return nil, nil
+	}
 	updated := 0
 	metrics := make([]prometheus.Metric, 0, len(q.Values))
 	for _, valueName := range q.Values {
@@ -172,7 +177,7 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 	labels = append(labels, conn.user)
 	labels = append(labels, valueName)
 	// create a new immutable const metric that can be cached and returned on
-	// every scrape. Remember that the order of the lable values in the labels
+	// every scrape. Remember that the order of the label values in the labels
 	// slice must match the order of the label names in the descriptor!
 	metric, err := prometheus.NewConstMetric(
 		q.desc, prometheus.GaugeValue, value, labels...,


### PR DESCRIPTION
With the recent addition of histograms to measure query times, we might have no interest in defining values for our queries.
Even with allow_zero_rows set to true, we still end up with errors within the logs. 
This PR corrects minor typos and adds a condition that will skip the updateMetrics if q.values is empty