### PR TITLE
Updating failedScrapes, incase of zero rows returned first time when SQL exported started(on initial time sql exported started)

### DIFF
--- a/query.go
+++ b/query.go
@@ -66,6 +66,7 @@ func (q *Query) Run(conn *connection) error {
 		if q.AllowZeroRows {
 			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
 		} else {
+			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
 			return fmt.Errorf("zero rows returned")
 		}
 	}

--- a/query.go
+++ b/query.go
@@ -67,6 +67,7 @@ func (q *Query) Run(conn *connection) error {
 			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
 		} else {
 			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+			failedQueryCounter.WithLabelValues(q.jobName, q.Name).Inc()
 			return fmt.Errorf("zero rows returned")
 		}
 	}


### PR DESCRIPTION
Scenario : Initially there is no data or zero rows returned for a SQL query for a particular DB and then if we start sql_exporter (metrics will be empty at this time). In this case, sql_exporter Metrics UI doesn't have any details to show that SQL query is executed and it is failed. 

With this change, SQL Exporter Metrics UI  helps and gives more detailed info to the user on query execution status. Instead of no logs for failed case (zero rows returned) now Metrics will have failed details.

Below is entry will come in Metrics with this code change.

sql_exporter_last_scrape_failed{database="DB",driver="postgres",host="hostNmae",query="sql_exporter_query",sql_job="sql_exporter_query",user="reader"} 1