### PR TITLE
add support to redact (hide) some of the labels in the metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ For a more realistic example please have a look at [examples/kubernetes/configma
 
 ```yaml
 ---
+# redacted_labels contains the list of standard labels you can hide from the generated
+# metrics, it supports the values: "host", "database", "user"
+redacted_labels: []
 # jobs is a map of jobs, define any number but please keep the connection usage on the DBs in mind
 jobs:
   # each job needs a unique name, it's used for logging and as a default label

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -1,4 +1,6 @@
 ---
+# supports "host", "database", "user"
+redacted_labels: []
 jobs:
 - name: "global"
   interval: '5m'

--- a/examples/kubernetes/configmap.yml
+++ b/examples/kubernetes/configmap.yml
@@ -6,6 +6,7 @@ metadata:
 data:
   config.yml: |
     ---
+    redacted_labels: []
     jobs:
     - name: "master-nodes"
       interval: '1m'
@@ -127,7 +128,7 @@ data:
         values:
           - "replication_lag"
         query:  |
-                WITH lag AS ( 
+                WITH lag AS (
                 SELECT
                   CASE
                     WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0

--- a/exporter.go
+++ b/exporter.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"cloud.google.com/go/cloudsqlconn"
 	"cloud.google.com/go/cloudsqlconn/mysql/mysql"
@@ -38,26 +37,15 @@ func NewExporter(logger log.Logger, configFile string) (*Exporter, error) {
 	}
 
 	// initialize global variables failedScrapes and redactedLabels
-	standardLabels := [6]string{"driver", "host", "database", "user", "sql_job", "query"}
-	var filteredLabels []string
-	for _, l := range standardLabels {
-		if !slices.Contains(cfg.RedactedLabels, l) {
-			filteredLabels = append(filteredLabels, l)
-		}
-	}
-
+	redactedLabels = cfg.RedactedLabels
 	failedScrapes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: fmt.Sprintf("%s_last_scrape_failed", metricsPrefix),
 			Help: "Failed scrapes",
 		},
-		filteredLabels,
+		GetLabelsForFailedScrapes(),
 	)
-
 	prometheus.MustRegister(failedScrapes)
-
-	redactedLabels = cfg.RedactedLabels
-	// TODO: end
 
 	var queryDurationHistogramBuckets []float64
 	if len(cfg.Configuration.HistogramBuckets) == 0 {

--- a/labels.go
+++ b/labels.go
@@ -1,0 +1,70 @@
+package main
+
+import "slices"
+
+func GetLabelsForFailedScrapes() []string {
+	standardLabels := [6]string{"driver", "host", "database", "user", "sql_job", "query"}
+	var labels []string
+	for _, l := range standardLabels {
+		if !slices.Contains(redactedLabels, l) {
+			labels = append(labels, l)
+		}
+	}
+
+	return labels
+}
+
+func GetLabelsForSQLGauges() []string {
+	standardLabels := [5]string{"driver", "host", "database", "user", "col"}
+	var labels []string
+	for _, l := range standardLabels {
+		if !slices.Contains(redactedLabels, l) {
+			labels = append(labels, l)
+		}
+	}
+
+	return labels
+}
+
+func AppendLabelValuesForSQLGauges(labels []string, conn *connection, valueName string) []string {
+	labels = append(labels, conn.driver)
+
+	if !slices.Contains(redactedLabels, "host") {
+		labels = append(labels, conn.host)
+	}
+
+	if !slices.Contains(redactedLabels, "database") {
+		labels = append(labels, conn.database)
+	}
+
+	if !slices.Contains(redactedLabels, "user") {
+		labels = append(labels, conn.user)
+	}
+
+	labels = append(labels, valueName)
+
+	return labels
+}
+
+func FilteredLabelValuesForFailedScrapes(conn *connection, q *Query) []string {
+	var labels []string
+
+	labels = append(labels, conn.driver)
+
+	if !slices.Contains(redactedLabels, "host") {
+		labels = append(labels, conn.host)
+	}
+
+	if !slices.Contains(redactedLabels, "database") {
+		labels = append(labels, conn.database)
+	}
+
+	if !slices.Contains(redactedLabels, "user") {
+		labels = append(labels, conn.user)
+	}
+
+	labels = append(labels, q.jobName)
+	labels = append(labels, q.Name)
+
+	return labels
+}

--- a/query.go
+++ b/query.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +34,7 @@ func (q *Query) Run(conn *connection) error {
 	now := time.Now()
 	rows, err := conn.conn.Queryx(q.Query)
 	if err != nil {
-		failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+		failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 		failedQueryCounter.WithLabelValues(q.jobName, q.Name).Inc()
 		return err
 	}
@@ -48,25 +49,25 @@ func (q *Query) Run(conn *connection) error {
 		err := rows.MapScan(res)
 		if err != nil {
 			level.Error(q.log).Log("msg", "Failed to scan", "err", err, "host", conn.host, "db", conn.database)
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 			continue
 		}
 		m, err := q.updateMetrics(conn, res, "", "")
 		if err != nil {
 			level.Error(q.log).Log("msg", "Failed to update metrics", "err", err, "host", conn.host, "db", conn.database)
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 			continue
 		}
 		metrics = append(metrics, m...)
 		updated++
-		failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
+		failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(0.0)
 	}
 
 	if updated < 1 {
 		if q.AllowZeroRows {
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(0.0)
 		} else {
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 			failedQueryCounter.WithLabelValues(q.jobName, q.Name).Inc()
 			return fmt.Errorf("zero rows returned")
 		}
@@ -106,7 +107,7 @@ func (q *Query) RunIterator(conn *connection, ph string, ivs []string, il string
 	for _, iv := range ivs {
 		rows, err := conn.conn.Queryx(q.ReplaceIterator(ph, iv))
 		if err != nil {
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 			failedQueryCounter.WithLabelValues(q.jobName, q.Name).Inc()
 			return err
 		}
@@ -117,18 +118,18 @@ func (q *Query) RunIterator(conn *connection, ph string, ivs []string, il string
 			err := rows.MapScan(res)
 			if err != nil {
 				level.Error(q.log).Log("msg", "Failed to scan", "err", err, "host", conn.host, "db", conn.database)
-				failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+				failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 				continue
 			}
 			m, err := q.updateMetrics(conn, res, iv, il)
 			if err != nil {
 				level.Error(q.log).Log("msg", "Failed to update metrics", "err", err, "host", conn.host, "db", conn.database)
-				failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(1.0)
+				failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(1.0)
 				continue
 			}
 			metrics = append(metrics, m...)
 			updated++
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(0.0)
 		}
 	}
 
@@ -137,7 +138,7 @@ func (q *Query) RunIterator(conn *connection, ph string, ivs []string, il string
 
 	if updated < 1 {
 		if q.AllowZeroRows {
-			failedScrapes.WithLabelValues(conn.driver, conn.host, conn.database, conn.user, q.jobName, q.Name).Set(0.0)
+			failedScrapes.WithLabelValues(q.filteredLabelValues(conn)...).Set(0.0)
 		} else {
 			return fmt.Errorf("zero rows returned")
 		}
@@ -149,6 +150,30 @@ func (q *Query) RunIterator(conn *connection, ph string, ivs []string, il string
 	q.Unlock()
 
 	return nil
+}
+
+func (q *Query) filteredLabelValues(conn *connection) []string {
+	var labels []string
+	if !slices.Contains(redactedLabels, "driver") {
+		labels = append(labels, conn.driver)
+	}
+	if !slices.Contains(redactedLabels, "host") {
+		labels = append(labels, conn.host)
+	}
+	if !slices.Contains(redactedLabels, "database") {
+		labels = append(labels, conn.database)
+	}
+	if !slices.Contains(redactedLabels, "user") {
+		labels = append(labels, conn.user)
+	}
+	if !slices.Contains(redactedLabels, "sql_job") {
+		labels = append(labels, q.jobName)
+	}
+	if !slices.Contains(redactedLabels, "query") {
+		labels = append(labels, q.Name)
+	}
+
+	return labels
 }
 
 // HasIterator returns true if the query contains the given placeholder
@@ -237,7 +262,7 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 	}
 	// make space for all defined variable label columns and the "static" labels
 	// added below
-	labels := make([]string, 0, len(q.Labels)+5)
+	labels := make([]string, 0, len(q.Labels)+(5-len(redactedLabels)))
 	for _, label := range q.Labels {
 		// append iterator value to the labels
 		if label == il && iv != "" {
@@ -262,11 +287,25 @@ func (q *Query) updateMetric(conn *connection, res map[string]interface{}, value
 		}
 		labels = append(labels, lv)
 	}
-	labels = append(labels, conn.driver)
-	labels = append(labels, conn.host)
-	labels = append(labels, conn.database)
-	labels = append(labels, conn.user)
-	labels = append(labels, valueName)
+
+	// TODO: start
+	if !slices.Contains(redactedLabels, "driver") {
+		labels = append(labels, conn.driver)
+	}
+	if !slices.Contains(redactedLabels, "host") {
+		labels = append(labels, conn.host)
+	}
+	if !slices.Contains(redactedLabels, "database") {
+		labels = append(labels, conn.database)
+	}
+	if !slices.Contains(redactedLabels, "user") {
+		labels = append(labels, conn.user)
+	}
+	if !slices.Contains(redactedLabels, "col") {
+		labels = append(labels, valueName)
+	}
+	// TODO: end
+
 	// create a new immutable const metric that can be cached and returned on
 	// every scrape. Remember that the order of the label values in the labels
 	// slice must match the order of the label names in the descriptor!


### PR DESCRIPTION
We use sql_exporter in our environments, but for us the following labels can be sensitive data:

- host
- database
- user

With this patch we add a global configuration entry `redacted_labels`, which specifies which labels can be omitted from metrics.