### PR TITLE
Add optional RSA key authentication and token regeneration support for Snowflake

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/robfig/cron/v3"
+	"github.com/snowflakedb/gosnowflake"
 	"gopkg.in/yaml.v2"
 )
 
@@ -164,6 +165,8 @@ type connection struct {
 	user                string
 	tokenExpirationTime time.Time
 	iteratorValues      []string
+    snowflakeConfig *gosnowflake.Config
+    snowflakeDSN    string
 }
 
 // Query is an SQL query that is executed on a connection

--- a/config.go
+++ b/config.go
@@ -165,8 +165,8 @@ type connection struct {
 	user                string
 	tokenExpirationTime time.Time
 	iteratorValues      []string
-    snowflakeConfig *gosnowflake.Config
-    snowflakeDSN    string
+    	snowflakeConfig *gosnowflake.Config
+    	snowflakeDSN    string
 }
 
 // Query is an SQL query that is executed on a connection


### PR DESCRIPTION
## Summary

This PR introduces **optional support for Snowflake JWT authentication using RSA private keys**, in addition to the existing password-based approach. It also implements **automatic token regeneration** to support long-lived or spaced query executions.

These enhancements maintain backward compatibility with existing configurations and require no changes for current users using password authentication.

---

## Key Changes

### 🔐 RSA Private Key Authentication (JWT)

- Adds support for reading PEM-encoded RSA private keys via the `private_key_file` URL query parameter.
- Builds a `gosnowflake.Config` with `AuthTypeJwt` using the RSA key.
- Allows users to securely authenticate with Snowflake using best practices recommended by Snowflake.

**Usage Example:**
```yaml
connections:
  - "snowflake://user@account?private_key_file=/key/mykey.pem&role=SYSADMIN"
```

### 🔁 Automatic JWT Token Regeneration
- Tracks token expiration time and **automatically regenerates** the connection/token before each job run if expired (default: every 1 hour).

- Enables safe execution of scheduled jobs with long intervals (e.g., 1h, 6h+) without risk of token expiry.

### Why This Matters
- **Security**: RSA keys provide stronger, more secure authentication than passwords.

- **Reliability**: Spaced jobs won't fail due to token expiry — ideal for Prometheus scraping Snowflake at longer intervals.

- **Flexibility**: Auth method is automatically inferred based on the presence of `private_key_file` in the connection string.

### Compatibility
✅ Fully backward compatible.
If `private_key_file` is not present, the connection will use the default password method as before.

### Related Files Modified
- `job.go`: Dual-mode auth logic (RSA vs. password), token tracking.

- `config.go`: Adds optional `snowflakeDSN` and `tokenExpirationTime` to connection struct.