### PR TITLE
changing docker file command to entrypoint so we can send arguments 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN chmod 0755 /usr/bin/sql_exporter
 
 USER prom
 
-CMD ["sql_exporter"]
+ENTRYPOINT ["sql_exporter"]


### PR DESCRIPTION
When using ENTRYPOINT instead of COMMAND in a Dockerfile, you gain flexibility when running containers with additional parameters:

With COMMAND: You must override the entire command to add flags
With ENTRYPOINT: You can simply append parameters to the base command
This change simplifies how we pass additional flags like --web.listen-address to the sql_exporter.

Before: using COMMAND
```
docker run \
  -v `pwd`/config.yml:/config/config.yml \
  -e CONFIG=/config/config.yml \
  -d \
  -p 9237:9237 \
  --name sql_exporter \
  ghcr.io/justwatchcom/sql_exporter \
  sql_exporter \
  --web.listen-address :9123
```
After: using ENTRYPOINT
```
docker run \
  -v `pwd`/config.yml:/config/config.yml \
  -e CONFIG=/config/config.yml \
  -d \
  -p 9237:9237 \
  --name sql_exporter \
  ghcr.io/justwatchcom/sql_exporter \
  --web.listen-address :9123
```